### PR TITLE
fix: issue #57 ログ機密対策とsession-id既定挙動を改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ multi-llm-agent-cli chat
 multi-llm-agent-cli use <model_name>
 ```
 
+### `chat`オプション (MVP)
+
+- `-s, --session-id <session_id>`: セッションIDを明示指定。未指定の場合は実行ごとに新規セッションIDが生成されます。
+- `--log-events`: チャットイベントログをローカル保存します（デフォルト無効）。
+  - 保存時は `user_input` / `assistant_response` の機密情報をマスクします。
+  - ログはローテーションされ、権限は所有者限定に設定されます。
+
 ## 開発フック
 
 コミット前とプッシュ前に品質チェックを強制するため、Git hookを利用します。

--- a/src/interaction/cli/commands/chat.command.ts
+++ b/src/interaction/cli/commands/chat.command.ts
@@ -11,6 +11,7 @@ interface ChatCommandInput {
   prompt?: string;
   model?: string;
   sessionId?: string;
+  enableEventLog?: boolean;
 }
 
 interface ChatCommandDeps {
@@ -24,7 +25,9 @@ export async function runChatCommand(
   deps: ChatCommandDeps,
 ): Promise<void> {
   const errorPresenter = new ErrorPresenter();
-  const logEvent = deps.logEvent ?? writeChatEventLog;
+  const logEvent: ChatEventLogger = input.enableEventLog
+    ? (deps.logEvent ?? writeChatEventLog)
+    : async () => {};
   const sessionId = input.sessionId ?? deps.createSessionId();
   const start = await deps.useCase.startSession({
     sessionId,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,15 @@
-import { Command } from 'commander';
-import { RunChatUseCase } from './application/chat/run-chat.usecase';
-import { ResolveModelUseCase } from './application/model-endpoint/resolve-model.usecase';
-import { FileConfigAdapter } from './adapters/config/file-config.adapter';
-import { OllamaClientAdapter } from './adapters/ollama/ollama-client.adapter';
-import { InMemorySessionStoreAdapter } from './adapters/session/in-memory-session-store.adapter';
-import { FileSessionStoreAdapter } from './adapters/session/file-session-store.adapter';
-import { runChatCommand } from './interaction/cli/commands/chat.command';
-import { LlmClientPort } from './ports/outbound/llm-client.port';
-import { ConfigPort } from './ports/outbound/config.port';
-import { SessionStorePort } from './ports/outbound/session-store.port';
+import { Command } from "commander";
+import { randomUUID } from "crypto";
+import { RunChatUseCase } from "./application/chat/run-chat.usecase";
+import { ResolveModelUseCase } from "./application/model-endpoint/resolve-model.usecase";
+import { FileConfigAdapter } from "./adapters/config/file-config.adapter";
+import { OllamaClientAdapter } from "./adapters/ollama/ollama-client.adapter";
+import { InMemorySessionStoreAdapter } from "./adapters/session/in-memory-session-store.adapter";
+import { FileSessionStoreAdapter } from "./adapters/session/file-session-store.adapter";
+import { runChatCommand } from "./interaction/cli/commands/chat.command";
+import { LlmClientPort } from "./ports/outbound/llm-client.port";
+import { ConfigPort } from "./ports/outbound/config.port";
+import { SessionStorePort } from "./ports/outbound/session-store.port";
 
 export function createProgram(deps?: {
   useCase?: RunChatUseCase;
@@ -18,49 +19,75 @@ export function createProgram(deps?: {
 }): Command {
   const config = deps?.config ?? new FileConfigAdapter();
   const llmClient = deps?.llmClient ?? new OllamaClientAdapter();
-  const sessionStore = deps?.sessionStore
-    ?? (process.env.NODE_ENV === 'test'
+  const sessionStore =
+    deps?.sessionStore ??
+    (process.env.NODE_ENV === "test"
       ? new InMemorySessionStoreAdapter()
       : new FileSessionStoreAdapter());
   const resolver = new ResolveModelUseCase(config, sessionStore);
-  const useCase = deps?.useCase ?? new RunChatUseCase(resolver, llmClient, sessionStore);
+  const useCase =
+    deps?.useCase ?? new RunChatUseCase(resolver, llmClient, sessionStore);
 
   const program = new Command();
 
   program
-    .name('multi-llm-agent-cli')
-    .description('Single-control-node oriented Multi LLM CLI')
-    .version('2.0.0-mvp');
+    .name("multi-llm-agent-cli")
+    .description("Single-control-node oriented Multi LLM CLI")
+    .version("2.0.0-mvp");
 
-  program.command('chat [prompt]')
-    .description('Run single-shot or interactive chat.')
-    .option('-m, --model <model_name>', 'Model name to use')
-    .option('-s, --session-id <session_id>', 'Session id for model/context reuse', 'default')
-    .action(async (prompt: string | undefined, options: { model?: string; sessionId?: string }) => {
-      try {
-        await runChatCommand({ prompt, model: options.model, sessionId: options.sessionId }, {
-          useCase,
-          createSessionId: () => `session-${Date.now()}`,
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`チャット実行中にエラーが発生しました: ${message}`);
-      }
-    });
+  program
+    .command("chat [prompt]")
+    .description("Run single-shot or interactive chat.")
+    .option("-m, --model <model_name>", "Model name to use")
+    .option(
+      "-s, --session-id <session_id>",
+      "Session id for model/context reuse (omitted: new session each run)",
+    )
+    .option(
+      "--log-events",
+      "Enable local chat event logging (masked + rotated)",
+    )
+    .action(
+      async (
+        prompt: string | undefined,
+        options: { model?: string; sessionId?: string; logEvents?: boolean },
+      ) => {
+        try {
+          await runChatCommand(
+            {
+              prompt,
+              model: options.model,
+              sessionId: options.sessionId,
+              enableEventLog: Boolean(options.logEvents),
+            },
+            {
+              useCase,
+              createSessionId: () => `session-${randomUUID()}`,
+            },
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          console.error(`チャット実行中にエラーが発生しました: ${message}`);
+        }
+      },
+    );
 
-  const modelCommand = program.command('model')
-    .description('Model operations.');
+  const modelCommand = program
+    .command("model")
+    .description("Model operations.");
 
-  modelCommand.command('list')
-    .description('List available models from Ollama.')
+  modelCommand
+    .command("list")
+    .description("List available models from Ollama.")
     .action(async () => {
       try {
         const models = await llmClient.listModels();
         if (models.length === 0) {
-          console.log('利用可能なモデルがありません。');
+          console.log("利用可能なモデルがありません。");
           return;
         }
-        console.log('利用可能なモデル:');
+        console.log("利用可能なモデル:");
         models.forEach((m) => console.log(`  - ${m.name}`));
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -68,8 +95,9 @@ export function createProgram(deps?: {
       }
     });
 
-  modelCommand.command('use <model_name>')
-    .description('Set default model.')
+  modelCommand
+    .command("use <model_name>")
+    .description("Set default model.")
     .action(async (modelName: string) => {
       try {
         const models = await llmClient.listModels();

--- a/src/operations/logging/chat-event-logger.ts
+++ b/src/operations/logging/chat-event-logger.ts
@@ -3,8 +3,9 @@ import * as os from "os";
 import * as path from "path";
 import { ModelResolutionSource } from "../../shared/types/chat";
 
-const LOG_DIR = path.join(os.homedir(), ".multi-llm-agent-cli", "logs");
-const CHAT_EVENT_LOG = path.join(LOG_DIR, "chat-events.jsonl");
+const DEFAULT_LOG_DIR = path.join(os.homedir(), ".multi-llm-agent-cli", "logs");
+const DEFAULT_LOG_FILE = "chat-events.jsonl";
+const DEFAULT_MAX_LOG_BYTES = 1024 * 1024;
 
 export interface ChatEventLogEntry {
   timestamp: string;
@@ -20,7 +21,111 @@ export interface ChatEventLogEntry {
 
 export type ChatEventLogger = (entry: ChatEventLogEntry) => Promise<void>;
 
+function resolveLogDir(): string {
+  const configured = process.env.CHAT_EVENT_LOG_DIR?.trim();
+  if (configured) {
+    return configured;
+  }
+
+  return DEFAULT_LOG_DIR;
+}
+
+function resolveLogFile(): string {
+  const configured = process.env.CHAT_EVENT_LOG_FILE?.trim();
+  if (configured) {
+    return configured;
+  }
+
+  return path.join(resolveLogDir(), DEFAULT_LOG_FILE);
+}
+
+function resolveMaxLogBytes(): number {
+  const configured = Number(process.env.CHAT_EVENT_LOG_MAX_BYTES);
+  if (Number.isFinite(configured) && configured > 0) {
+    return configured;
+  }
+
+  return DEFAULT_MAX_LOG_BYTES;
+}
+
+async function safeChmod(targetPath: string, mode: number): Promise<void> {
+  try {
+    await fsp.chmod(targetPath, mode);
+  } catch {
+    // Ignore chmod errors to keep logging best-effort across OS.
+  }
+}
+
+function shouldHardenDirectoryPermissions(logDir: string): boolean {
+  const configuredLogFile = process.env.CHAT_EVENT_LOG_FILE?.trim();
+  if (configuredLogFile) {
+    return false;
+  }
+
+  return path.resolve(logDir) === path.resolve(resolveLogDir());
+}
+
+async function rotateIfNeeded(
+  logFile: string,
+  maxBytes: number,
+): Promise<void> {
+  try {
+    const stat = await fsp.stat(logFile);
+    if (stat.size < maxBytes) {
+      return;
+    }
+
+    const rotated = `${logFile}.${new Date().toISOString().replace(/[:.]/g, "-")}`;
+    await fsp.rename(logFile, rotated);
+    await safeChmod(rotated, 0o600);
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+function maskSensitiveText(text: string): string {
+  return text
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[REDACTED_EMAIL]")
+    .replace(/\b(?:sk|pk)-[A-Za-z0-9_-]{16,}\b/g, "[REDACTED_KEY]")
+    .replace(/\b(?:Bearer\s+)?[A-Za-z0-9._-]{32,}\b/g, "[REDACTED_TOKEN]")
+    .replace(/\b(?:\d[ -]?){13,19}\b/g, "[REDACTED_NUMBER]");
+}
+
+export function sanitizeChatEventLogEntry(
+  entry: ChatEventLogEntry,
+): ChatEventLogEntry {
+  return {
+    ...entry,
+    user_input: entry.user_input
+      ? maskSensitiveText(entry.user_input)
+      : entry.user_input,
+    assistant_response: entry.assistant_response
+      ? maskSensitiveText(entry.assistant_response)
+      : entry.assistant_response,
+  };
+}
+
 export const writeChatEventLog: ChatEventLogger = async (entry) => {
-  await fsp.mkdir(LOG_DIR, { recursive: true });
-  await fsp.appendFile(CHAT_EVENT_LOG, `${JSON.stringify(entry)}\n`, "utf-8");
+  const logFile = resolveLogFile();
+  const logDir = path.dirname(logFile);
+  const maxBytes = resolveMaxLogBytes();
+
+  await fsp.mkdir(logDir, { recursive: true });
+  if (shouldHardenDirectoryPermissions(logDir)) {
+    await safeChmod(logDir, 0o700);
+  }
+  await rotateIfNeeded(logFile, maxBytes);
+
+  const payload = `${JSON.stringify(sanitizeChatEventLogEntry(entry))}\n`;
+  const handle = await fsp.open(logFile, "a", 0o600);
+  try {
+    await handle.appendFile(payload, "utf-8");
+  } finally {
+    await handle.close();
+  }
+  await safeChmod(logFile, 0o600);
 };

--- a/src/tests/acceptance/features/F-001.chat.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-001.chat.acceptance.test.ts
@@ -81,7 +81,12 @@ describe("F-001 CLI Chat acceptance", () => {
     const logEvent = jest.fn().mockResolvedValue(undefined);
 
     await runChatCommand(
-      { prompt: "hello?", model: "model-a", sessionId: "session-structured" },
+      {
+        prompt: "hello?",
+        model: "model-a",
+        sessionId: "session-structured",
+        enableEventLog: true,
+      },
       { useCase, createSessionId: () => "session-1", logEvent },
     );
 
@@ -107,5 +112,17 @@ describe("F-001 CLI Chat acceptance", () => {
         duration_ms: expect.any(Number),
       }),
     );
+  });
+
+  it("does not record chat events by default", async () => {
+    const useCase = createMockUseCase("model-a");
+    const logEvent = jest.fn().mockResolvedValue(undefined);
+
+    await runChatCommand(
+      { prompt: "hello?", model: "model-a", sessionId: "session-no-log" },
+      { useCase, createSessionId: () => "session-1", logEvent },
+    );
+
+    expect(logEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/unit/application/main.program.test.ts
+++ b/src/tests/unit/application/main.program.test.ts
@@ -1,39 +1,67 @@
-import { createProgram } from '../../../main';
-import { RunChatUseCase } from '../../../application/chat/run-chat.usecase';
+import { createProgram } from "../../../main";
+import { RunChatUseCase } from "../../../application/chat/run-chat.usecase";
 
-describe('createProgram', () => {
+describe("createProgram", () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('registers model subcommands without duplicate command error', () => {
+  it("registers model subcommands without duplicate command error", () => {
     const program = createProgram();
-    const model = program.commands.find((cmd) => cmd.name() === 'model');
+    const model = program.commands.find((cmd) => cmd.name() === "model");
 
     expect(model).toBeDefined();
-    expect(model?.commands.map((cmd) => cmd.name())).toEqual(expect.arrayContaining(['list', 'use']));
+    expect(model?.commands.map((cmd) => cmd.name())).toEqual(
+      expect.arrayContaining(["list", "use"]),
+    );
   });
 
-  it('passes sessionId to chat command input', async () => {
+  it("passes sessionId to chat command input", async () => {
     const useCase = {
       startSession: jest.fn().mockResolvedValue({
         ok: true,
-        model: 'test-model',
-        source: 'default',
+        model: "test-model",
+        source: "default",
       }),
       runTurn: jest.fn(async function* () {
-        yield 'ok';
+        yield "ok";
       }),
     } as unknown as RunChatUseCase;
 
     const program = createProgram({ useCase });
-    jest.spyOn(console, 'log').mockImplementation(() => {});
-    jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(process.stdout, "write").mockImplementation(() => true);
 
-    await program.parseAsync(['chat', '--session-id', 's-001', 'hello'], { from: 'user' });
+    await program.parseAsync(["chat", "--session-id", "s-001", "hello"], {
+      from: "user",
+    });
 
     expect((useCase as any).startSession).toHaveBeenCalledWith({
-      sessionId: 's-001',
+      sessionId: "s-001",
+      cliModel: undefined,
+    });
+  });
+
+  it("creates a new session id when --session-id is omitted", async () => {
+    const useCase = {
+      startSession: jest.fn().mockResolvedValue({
+        ok: true,
+        model: "test-model",
+        source: "default",
+      }),
+      runTurn: jest.fn(async function* () {
+        yield "ok";
+      }),
+    } as unknown as RunChatUseCase;
+
+    const program = createProgram({ useCase });
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await program.parseAsync(["chat", "hello"], { from: "user" });
+
+    expect((useCase as any).startSession).toHaveBeenCalledWith({
+      sessionId: expect.stringMatching(/^session-[0-9a-f-]{36}$/),
       cliModel: undefined,
     });
   });

--- a/src/tests/unit/operations/chat-event-logger.test.ts
+++ b/src/tests/unit/operations/chat-event-logger.test.ts
@@ -1,0 +1,99 @@
+import { promises as fsp } from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  sanitizeChatEventLogEntry,
+  writeChatEventLog,
+} from "../../../operations/logging/chat-event-logger";
+
+describe("chat-event-logger", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "chat-event-logger-"));
+  });
+
+  afterEach(async () => {
+    delete process.env.CHAT_EVENT_LOG_DIR;
+    delete process.env.CHAT_EVENT_LOG_FILE;
+    delete process.env.CHAT_EVENT_LOG_MAX_BYTES;
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("masks sensitive values in chat payloads", () => {
+    const entry = sanitizeChatEventLogEntry({
+      timestamp: "2026-02-15T00:00:00.000Z",
+      session_id: "s-1",
+      event_type: "turn_completed",
+      model: "test-model",
+      resolution_source: "default",
+      user_input:
+        "mail test@example.com token sk-12345678901234567890 card 4111-1111-1111-1111",
+      assistant_response:
+        "Bearer thisisaverylongtokenvalue01234567890123456789",
+      duration_ms: 10,
+    });
+
+    expect(entry.user_input).toContain("[REDACTED_EMAIL]");
+    expect(entry.user_input).toContain("[REDACTED_KEY]");
+    expect(entry.user_input).toContain("[REDACTED_NUMBER]");
+    expect(entry.user_input).not.toContain("test@example.com");
+    expect(entry.assistant_response).toContain("[REDACTED_TOKEN]");
+  });
+
+  it("rotates log file by size and writes with owner-only permission", async () => {
+    const logFile = path.join(tempDir, "chat-events.jsonl");
+    process.env.CHAT_EVENT_LOG_FILE = logFile;
+    process.env.CHAT_EVENT_LOG_MAX_BYTES = "120";
+
+    await writeChatEventLog({
+      timestamp: "2026-02-15T00:00:00.000Z",
+      session_id: "s-1",
+      event_type: "turn_completed",
+      model: "test-model",
+      resolution_source: "default",
+      user_input: "x".repeat(240),
+      assistant_response: "ok",
+      duration_ms: 10,
+    });
+    await writeChatEventLog({
+      timestamp: "2026-02-15T00:00:01.000Z",
+      session_id: "s-1",
+      event_type: "turn_completed",
+      model: "test-model",
+      resolution_source: "default",
+      user_input: "second",
+      assistant_response: "ok",
+      duration_ms: 10,
+    });
+
+    const files = await fsp.readdir(tempDir);
+    const rotated = files.filter((f) => f.startsWith("chat-events.jsonl."));
+    expect(rotated.length).toBeGreaterThan(0);
+
+    const current = await fsp.readFile(logFile, "utf-8");
+    expect(current).toContain('"user_input":"second"');
+
+    const stat = await fsp.stat(logFile);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("does not chmod arbitrary parent directory when CHAT_EVENT_LOG_FILE is set", async () => {
+    const customDir = path.join(tempDir, "custom");
+    const customLogFile = path.join(customDir, "events.log");
+    process.env.CHAT_EVENT_LOG_FILE = customLogFile;
+    const chmodSpy = jest.spyOn(fsp, "chmod");
+
+    await writeChatEventLog({
+      timestamp: "2026-02-15T00:00:00.000Z",
+      session_id: "s-1",
+      event_type: "session_start",
+      model: "test-model",
+      resolution_source: "default",
+    });
+
+    expect(chmodSpy).not.toHaveBeenCalledWith(customDir, 0o700);
+    expect(chmodSpy).toHaveBeenCalledWith(customLogFile, 0o600);
+    chmodSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## 概要 (Summary)
Issue #57 のフォローアップとして、チャットイベントログの機密対策と `--session-id` 未指定時の既定挙動を改善しました。

## 関連Issue (Related Issues)
Closes #57

## 変更の種類 (Type of Change)
- [ ] 新機能 (New feature)
- [x] バグ修正 (Bug fix)
- [x] リファクタリング (Refactoring)
- [x] ドキュメント更新 (Documentation)

## 詳細な変更点 (Detailed Changes)
- `src/main.ts`: `chat` コマンドに `--log-events` を追加し、`--session-id` 未指定時は `session-${randomUUID()}` を生成するよう変更。
- `src/interaction/cli/commands/chat.command.ts`: イベントログをデフォルト無効化し、`enableEventLog` が true のときのみロガーを実行。
- `src/operations/logging/chat-event-logger.ts`: 
  - `user_input` / `assistant_response` のパターンベースマスキングを追加
  - サイズ閾値ベースのローテーションを追加
  - ファイル権限を `600` 相当に調整
  - `CHAT_EVENT_LOG_FILE` 指定時に任意ディレクトリへ `chmod 700` しない安全ガードを追加
- `src/tests/acceptance/features/F-001.chat.acceptance.test.ts`: ログ無効デフォルト/有効時ログ出力の受け入れテストを更新。
- `src/tests/unit/application/main.program.test.ts`: `--session-id` 未指定時の新規セッションID生成（UUID形式）を検証。
- `src/tests/unit/operations/chat-event-logger.test.ts`: マスキング、ローテーション、権限、`chmod` ガードを検証するユニットテストを追加。
- `README.md`: `chat` オプション仕様（`--session-id` 未指定挙動、`--log-events`）を追記。

## 動作確認手順 (Verification Steps)
1. `npm test`
2. `npm run lint`

## 自己チェック (Self Check)
- [x] 既存のテストを壊していないか
- [x] 機密情報（API Key等）が含まれていないか
