### PR TITLE
feat: implement S1.2 streaming UX for issue #37

### DIFF
--- a/doc/CURRENT_PLAN.md
+++ b/doc/CURRENT_PLAN.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Issue #37 S1.2 ストリーミングUX
+
+## 1. 概要とゴール (Summary & Goal)
+
+- **Must**:
+  - 応答テキストを完了前に逐次表示し続ける（既存の逐次表示を維持）。
+  - 実行中であることをユーザーが識別できる表示を追加する（`Generating...` 相当）。
+  - 応答の完了を明示する（done表示/状態更新/改行完了）。
+  - ストリーミングの順序保証をテストで担保する。
+  - F-002 の DoD（逐次表示、順序保持、実行中/完了表示）に適合する。
+- **Want**:
+  - 表示状態（pending/running/succeeded など）の全コマンド統一。
+  - headless 向けイベント出力設計の同時拡張。
+
+## 2. スコープ定義 (Scope Definition)
+
+### ✅ In-Scope (やること)
+
+- `src/interaction/cli/commands/chat.command.ts`
+  - 1ターン中の表示状態を追加（開始時: 実行中、終了時: 完了）。
+  - 逐次トークン表示の前後メッセージを最小変更で実装。
+- `src/application/chat/run-chat.usecase.ts`
+  - 既存の `runTurn` の順序性・終了条件を保持し、必要なら補助的な安全策のみ追加。
+- `src/tests/unit/interaction/chat.command.test.ts`
+  - 実行中表示と完了表示が出ることを検証。
+  - 既存の逐次処理直列化テストを維持し、回帰を防ぐ。
+- `src/tests/unit/application/run-chat.usecase.test.ts`
+  - チャンク順序保持・`done` で終了することを明示的に検証（T1.2.3）。
+- `src/tests/acceptance/features/F-002.streaming.acceptance.test.ts`（新規）
+  - F-002 観点の受け入れテストを追加し、CLIでの可視挙動を確認。
+
+### ⛔ Non-Goals (やらないこと/スコープ外)
+
+- **リッチUI化**: TUI/GUI、スピナーライブラリ導入、装飾的レンダリングは行わない。
+- **広範囲リファクタリング**: `src/cli/commands/*` や他機能（F-004以降）の設計変更は行わない。
+- **ログ仕様拡張**: 監査ログスキーマの大規模変更や新規ログ基盤導入は行わない。
+- **依存追加**: 新しい外部ライブラリは追加しない。
+
+## 3. 実装ステップ (Implementation Steps)
+
+1. [ ] **Step 1: 現行ストリーミング経路の固定化**
+   - _Action_: `src/application/chat/run-chat.usecase.ts` の `runTurn` 挙動（順序・done終了）を仕様化するテストを先に追加/補強。
+   - _Validation_: `src/tests/unit/application/run-chat.usecase.test.ts` で順序保証ケースが通る。
+
+2. [ ] **Step 2: 実行中/完了表示の追加**
+   - _Action_: `src/interaction/cli/commands/chat.command.ts` の `streamOneTurn` に実行中表示（開始）と完了表示（終了）を追加。
+   - _Action_: 既存の `AI: ` プレフィックスと逐次 `process.stdout.write` の順序を壊さない。
+   - _Validation_: `src/tests/unit/interaction/chat.command.test.ts` で表示文言と呼び出し順を検証。
+
+3. [ ] **Step 3: F-002 受け入れテストの追加**
+   - _Action_: `src/tests/acceptance/features/F-002.streaming.acceptance.test.ts` を追加し、以下を検証。
+     - 完了前にチャンクが表示される。
+     - 実行中表示と完了表示がユーザー可視である。
+     - 重複表示せず順序が維持される。
+   - _Validation_: `npm test` で新規 acceptance を含めて成功。
+
+4. [ ] **Step 4: 最終検証と差分確認**
+   - _Action_: 変更ファイルが計画内に限定されていることを確認。
+   - _Validation_: F-002 DoD との対応表をPR説明に転記できる粒度で確認。
+
+## 4. 検証プラン (Verification Plan)
+
+- 必須テスト:
+  - `npm test -- src/tests/unit/application/run-chat.usecase.test.ts`
+  - `npm test -- src/tests/unit/interaction/chat.command.test.ts`
+  - `npm test -- src/tests/acceptance/features/F-002.streaming.acceptance.test.ts`
+- 最終テスト:
+  - `npm test`
+- 手動確認:
+  - `chat "hello"` 実行時に、応答本文の逐次表示に加えて実行中表示が見える。
+  - 応答終了時に完了が明示される（done表示または同等の完了サイン）。
+  - 応答テキストの表示順が入力順・生成順と一致する。
+
+## 5. ガードレール (Guardrails for Coding Agent)
+
+- `doc/CURRENT_PLAN.md` に記載のないファイル変更は禁止する。
+- 実装中に仕様追加が必要になった場合は、コード変更前に本計画を更新して承認を得る。
+- 表示文言を変更する場合、対応するテスト期待値を同時更新し、意図をコメントまたはPR説明に残す。
+- 既存の逐次出力ロジックを破壊しないことを最優先とし、必要最小限の差分で実装する。

--- a/src/interaction/cli/commands/chat.command.ts
+++ b/src/interaction/cli/commands/chat.command.ts
@@ -64,6 +64,7 @@ export async function runChatCommand(
   const streamOneTurn = async (prompt: string): Promise<void> => {
     const startedAt = Date.now();
     messages.push({ role: "user", content: prompt });
+    console.log("Generating...");
     process.stdout.write("AI: ");
 
     let response = "";
@@ -74,6 +75,7 @@ export async function runChatCommand(
       }
 
       process.stdout.write("\n");
+      console.log("Done.");
       messages.push({ role: "assistant", content: response });
 
       await safeLog({

--- a/src/tests/acceptance/features/F-002.streaming.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-002.streaming.acceptance.test.ts
@@ -1,0 +1,55 @@
+import { runChatCommand } from "../../../interaction/cli/commands/chat.command";
+import { RunChatUseCase } from "../../../application/chat/run-chat.usecase";
+
+function createMockUseCase() {
+  return {
+    startSession: jest.fn().mockResolvedValue({
+      ok: true,
+      model: "stream-model",
+      source: "default",
+    }),
+    runTurn: jest.fn(async function* () {
+      yield "first";
+      yield "-second";
+      yield "-third";
+    }),
+  } as unknown as RunChatUseCase;
+}
+
+describe("F-002 Streaming UX acceptance", () => {
+  let logSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+  let writeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    writeSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows running/completed markers and streams chunks in order without duplication", async () => {
+    const useCase = createMockUseCase();
+
+    await runChatCommand(
+      { prompt: "hello stream" },
+      { useCase, createSessionId: () => "session-f002" },
+    );
+
+    expect(writeSpy.mock.calls).toEqual([
+      ["AI: "],
+      ["first"],
+      ["-second"],
+      ["-third"],
+      ["\n"],
+    ]);
+    expect(logSpy).toHaveBeenCalledWith("Generating...");
+    expect(logSpy).toHaveBeenCalledWith("Done.");
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/application/run-chat.usecase.test.ts
+++ b/src/tests/unit/application/run-chat.usecase.test.ts
@@ -1,9 +1,12 @@
-import { RunChatUseCase } from '../../../application/chat/run-chat.usecase';
-import { ResolveModelUseCase } from '../../../application/model-endpoint/resolve-model.usecase';
-import { ConfigPort } from '../../../ports/outbound/config.port';
-import { LlmClientPort, ModelSummary } from '../../../ports/outbound/llm-client.port';
-import { SessionStorePort } from '../../../ports/outbound/session-store.port';
-import { ChatChunk, ChatMessage } from '../../../shared/types/chat';
+import { RunChatUseCase } from "../../../application/chat/run-chat.usecase";
+import { ResolveModelUseCase } from "../../../application/model-endpoint/resolve-model.usecase";
+import { ConfigPort } from "../../../ports/outbound/config.port";
+import {
+  LlmClientPort,
+  ModelSummary,
+} from "../../../ports/outbound/llm-client.port";
+import { SessionStorePort } from "../../../ports/outbound/session-store.port";
+import { ChatChunk, ChatMessage } from "../../../shared/types/chat";
 
 class FakeSessionStore implements SessionStorePort {
   private modelMap = new Map<string, string>();
@@ -37,72 +40,119 @@ class FakeLlmClient implements LlmClientPort {
     return this.models;
   }
 
-  async *chat(_model: string, _messages: ChatMessage[]): AsyncGenerator<ChatChunk> {
+  async *chat(
+    _model: string,
+    _messages: ChatMessage[],
+  ): AsyncGenerator<ChatChunk> {
     for (const chunk of this.chunks) {
       yield chunk;
     }
   }
 }
 
-describe('RunChatUseCase', () => {
-  it('starts session with resolved model and persists it', async () => {
+describe("RunChatUseCase", () => {
+  it("starts session with resolved model and persists it", async () => {
     const sessionStore = new FakeSessionStore();
-    const resolver = new ResolveModelUseCase(new FakeConfig('default-model'), sessionStore);
+    const resolver = new ResolveModelUseCase(
+      new FakeConfig("default-model"),
+      sessionStore,
+    );
     const useCase = new RunChatUseCase(
       resolver,
-      new FakeLlmClient([{ name: 'default-model' }]),
+      new FakeLlmClient([{ name: "default-model" }]),
       sessionStore,
     );
 
-    const result = await useCase.startSession({ sessionId: 's-1' });
+    const result = await useCase.startSession({ sessionId: "s-1" });
 
-    expect(result).toEqual({ ok: true, model: 'default-model', source: 'default' });
-    await expect(sessionStore.getModel('s-1')).resolves.toBe('default-model');
+    expect(result).toEqual({
+      ok: true,
+      model: "default-model",
+      source: "default",
+    });
+    await expect(sessionStore.getModel("s-1")).resolves.toBe("default-model");
   });
 
-  it('returns actionable error when model is missing', async () => {
+  it("returns actionable error when model is missing", async () => {
     const sessionStore = new FakeSessionStore();
-    const resolver = new ResolveModelUseCase(new FakeConfig('missing-model'), sessionStore);
+    const resolver = new ResolveModelUseCase(
+      new FakeConfig("missing-model"),
+      sessionStore,
+    );
     const useCase = new RunChatUseCase(
       resolver,
-      new FakeLlmClient([{ name: 'available-model' }]),
+      new FakeLlmClient([{ name: "available-model" }]),
       sessionStore,
     );
 
-    const result = await useCase.startSession({ sessionId: 's-1' });
+    const result = await useCase.startSession({ sessionId: "s-1" });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result).toEqual({
         ok: false,
-        code: 'MODEL_NOT_FOUND',
-        model: 'missing-model',
-        candidates: ['available-model'],
+        code: "MODEL_NOT_FOUND",
+        model: "missing-model",
+        candidates: ["available-model"],
       });
     }
   });
 
-  it('streams tokens for one turn', async () => {
+  it("streams tokens for one turn", async () => {
     const sessionStore = new FakeSessionStore();
-    const resolver = new ResolveModelUseCase(new FakeConfig('default-model'), sessionStore);
+    const resolver = new ResolveModelUseCase(
+      new FakeConfig("default-model"),
+      sessionStore,
+    );
     const useCase = new RunChatUseCase(
       resolver,
       new FakeLlmClient(
-        [{ name: 'default-model' }],
+        [{ name: "default-model" }],
         [
-          { content: 'Hello', done: false },
-          { content: ' world', done: false },
-          { content: '', done: true },
+          { content: "Hello", done: false },
+          { content: " world", done: false },
+          { content: "", done: true },
         ],
       ),
       sessionStore,
     );
 
     const received: string[] = [];
-    for await (const token of useCase.runTurn('default-model', [{ role: 'user', content: 'Hi' }])) {
+    for await (const token of useCase.runTurn("default-model", [
+      { role: "user", content: "Hi" },
+    ])) {
       received.push(token);
     }
 
-    expect(received).toEqual(['Hello', ' world']);
+    expect(received).toEqual(["Hello", " world"]);
+  });
+
+  it("stops yielding tokens when done chunk is received", async () => {
+    const sessionStore = new FakeSessionStore();
+    const resolver = new ResolveModelUseCase(
+      new FakeConfig("default-model"),
+      sessionStore,
+    );
+    const useCase = new RunChatUseCase(
+      resolver,
+      new FakeLlmClient(
+        [{ name: "default-model" }],
+        [
+          { content: "A", done: false },
+          { content: "B", done: true },
+          { content: "C", done: false },
+        ],
+      ),
+      sessionStore,
+    );
+
+    const received: string[] = [];
+    for await (const token of useCase.runTurn("default-model", [
+      { role: "user", content: "Hi" },
+    ])) {
+      received.push(token);
+    }
+
+    expect(received).toEqual(["A", "B"]);
   });
 });

--- a/src/tests/unit/interaction/chat.command.test.ts
+++ b/src/tests/unit/interaction/chat.command.test.ts
@@ -104,4 +104,34 @@ describe("chat.command interaction serialization", () => {
       ]),
     );
   });
+
+  it("prints running and completed status for each turn", async () => {
+    const useCase = {
+      startSession: jest.fn().mockResolvedValue({
+        ok: true,
+        model: "test-model",
+        source: "default",
+      }),
+      runTurn: jest.fn(async function* () {
+        yield "chunk-1";
+        yield "chunk-2";
+      }),
+    } as unknown as RunChatUseCase;
+
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runChatCommand(
+      { prompt: "hello" },
+      {
+        useCase,
+        createSessionId: () => "session-1",
+        logEvent: jest.fn().mockResolvedValue(undefined),
+      },
+    );
+
+    expect(logSpy).toHaveBeenCalledWith("Generating...");
+    expect(logSpy).toHaveBeenCalledWith("Done.");
+  });
 });


### PR DESCRIPTION
## Summary
- Add running/completed markers (Generating..., Done.) in chat streaming turns
- Keep token-by-token output behavior and add done-stop coverage
- Add F-002 acceptance test for streaming order/state visibility
- Add implementation plan document for Issue #37

## Scope
- In scope: F-002 streaming UX (src/interaction, src/tests, doc/CURRENT_PLAN.md)
- Out of scope: rich UI rendering, dependency additions

## Verification
- npm test -- src/tests/unit/application/run-chat.usecase.test.ts
- npm test -- src/tests/unit/interaction/chat.command.test.ts
- npm test -- src/tests/acceptance/features/F-002.streaming.acceptance.test.ts
- npm test

Closes #37
