### PR TITLE
feat: implement session/context controls for issue #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ multi-llm-agent-cli use <model_name>
   - 保存時は `user_input` / `assistant_response` の機密情報をマスクします。
   - ログはローテーションされ、権限は所有者限定に設定されます。
 
+### `session` コマンド (MVP)
+
+- `session start [session_id]`: セッションを開始します（`--model`, `--max-turns`, `--summary` を指定可能）。
+- `session save <session_id>`: セッションの保存時刻を更新し、スナップショットを確定します。
+- `session load <session_id>`: 保存済みセッションのモデル/履歴件数/コンテキスト方針を表示します。
+- `session end <session_id>`: セッションを終了し、保存データを削除します。
+- `session context show|set|clear|summarize <session_id>`:
+  - `show`: 現在の保持件数・要約有無・履歴件数を表示
+  - `set --max-turns N --summary on|off`: 保持件数/自動要約を設定
+  - `clear --keep-turns N`: 履歴を破棄（最新Nターンのみ保持、既存summaryも破棄）
+  - `summarize`: 古い履歴を要約して圧縮
+
 ## 開発フック
 
 コミット前とプッシュ前に品質チェックを強制するため、Git hookを利用します。

--- a/doc/CURRENT_PLAN.md
+++ b/doc/CURRENT_PLAN.md
@@ -1,79 +1,102 @@
-# Implementation Plan: Issue #37 S1.2 ストリーミングUX
+# Implementation Plan: Issue #38 S1.3 セッション・コンテキスト
 
 ## 1. 概要とゴール (Summary & Goal)
 
 - **Must**:
-  - 応答テキストを完了前に逐次表示し続ける（既存の逐次表示を維持）。
-  - 実行中であることをユーザーが識別できる表示を追加する（`Generating...` 相当）。
-  - 応答の完了を明示する（done表示/状態更新/改行完了）。
-  - ストリーミングの順序保証をテストで担保する。
-  - F-002 の DoD（逐次表示、順序保持、実行中/完了表示）に適合する。
+  - `session start/save/load/end` を CLI から実行できる。
+  - セッション保存後、`load` で会話文脈（最低: モデル設定 + 会話履歴）が再利用できる。
+  - コンテキスト管理として「履歴保持」「明示破棄」「最小要約圧縮」をユーザー操作で制御できる。
+  - チャット実行時にコンテキスト方針（保持件数、圧縮有無）を確認できる。
+  - F-004/F-005 の DoD を満たす回帰テストを追加する。
 - **Want**:
-  - 表示状態（pending/running/succeeded など）の全コマンド統一。
-  - headless 向けイベント出力設計の同時拡張。
+  - トークン数の高精度見積もり。
+  - 複数ノード間のセッション共有。
+  - 高度な要約アルゴリズム（段階要約・意味圧縮最適化）。
 
 ## 2. スコープ定義 (Scope Definition)
 
 ### ✅ In-Scope (やること)
 
-- `src/interaction/cli/commands/chat.command.ts`
-  - 1ターン中の表示状態を追加（開始時: 実行中、終了時: 完了）。
-  - 逐次トークン表示の前後メッセージを最小変更で実装。
+- `src/ports/outbound/session-store.port.ts`
+  - モデル保存だけでなく、セッション状態（履歴・メタ・コンテキスト方針）を扱える最小 API を追加。
+- `src/adapters/session/in-memory-session-store.adapter.ts`
+  - 新しい SessionStorePort 契約に追従し、テスト用の完全動作実装を追加。
+- `src/adapters/session/file-session-store.adapter.ts`
+  - `~/.multi-llm-agent-cli/session.json` を拡張し、セッション情報の保存/復元/削除を実装。
 - `src/application/chat/run-chat.usecase.ts`
-  - 既存の `runTurn` の順序性・終了条件を保持し、必要なら補助的な安全策のみ追加。
-- `src/tests/unit/interaction/chat.command.test.ts`
-  - 実行中表示と完了表示が出ることを検証。
-  - 既存の逐次処理直列化テストを維持し、回帰を防ぐ。
+  - セッション開始・読込結果を使って、1ターン実行時の入力コンテキストを組み立てる責務を最小追加。
+- `src/interaction/cli/commands/chat.command.ts`
+  - `sessionId` 指定時の履歴反映、ターン完了時の履歴更新、コンテキスト方針表示を追加。
+- `src/main.ts`
+  - `session start/save/load/end` コマンドを追加し、既存 `chat` と同じ use case / store を利用。
 - `src/tests/unit/application/run-chat.usecase.test.ts`
-  - チャンク順序保持・`done` で終了することを明示的に検証（T1.2.3）。
-- `src/tests/acceptance/features/F-002.streaming.acceptance.test.ts`（新規）
-  - F-002 観点の受け入れテストを追加し、CLIでの可視挙動を確認。
+  - セッション復元・保持件数・破棄・要約反映のユニットテストを追加。
+- `src/tests/unit/application/main.program.test.ts`
+  - `session` サブコマンド登録と引数受け渡しを検証。
+- `src/tests/acceptance/features/F-004.session.acceptance.test.ts`（新規）
+  - 保存→復元で文脈再利用されることを検証。
+- `src/tests/acceptance/features/F-005.context.acceptance.test.ts`（新規）
+  - 保持/破棄/要約の操作結果が次ターンに反映されることを検証。
+- `README.md`
+  - `session` コマンドとコンテキスト管理の MVP 仕様を最小追記。
 
 ### ⛔ Non-Goals (やらないこと/スコープ外)
 
-- **リッチUI化**: TUI/GUI、スピナーライブラリ導入、装飾的レンダリングは行わない。
-- **広範囲リファクタリング**: `src/cli/commands/*` や他機能（F-004以降）の設計変更は行わない。
-- **ログ仕様拡張**: 監査ログスキーマの大規模変更や新規ログ基盤導入は行わない。
-- **依存追加**: 新しい外部ライブラリは追加しない。
+- **分散セッション同期**: 複数マシン・複数プロセス間の同期は実装しない。
+- **大規模リファクタリング**: 既存のモジュール構成全面変更は行わない。
+- **新規依存追加**: 要約や永続化のために新しい外部ライブラリは導入しない。
+- **高度メモリ戦略**: ベクトルDB連携、長期記憶、自動重要度抽出は対象外。
+- **F-006/F-007 の同時拡張**: event-output/headless の新機能追加は行わない。
 
 ## 3. 実装ステップ (Implementation Steps)
 
-1. [ ] **Step 1: 現行ストリーミング経路の固定化**
-   - _Action_: `src/application/chat/run-chat.usecase.ts` の `runTurn` 挙動（順序・done終了）を仕様化するテストを先に追加/補強。
-   - _Validation_: `src/tests/unit/application/run-chat.usecase.test.ts` で順序保証ケースが通る。
+1. [ ] **Step 1: セッションデータ契約を定義する**
+   - _Action_: `SessionStorePort` にセッション状態取得/保存/終了 API を追加し、型を定義する。
+   - _Action_: in-memory / file adapter を同契約へ合わせる。
+   - _Validation_: 既存 F-003 テストが回帰しないことを確認。
 
-2. [ ] **Step 2: 実行中/完了表示の追加**
-   - _Action_: `src/interaction/cli/commands/chat.command.ts` の `streamOneTurn` に実行中表示（開始）と完了表示（終了）を追加。
-   - _Action_: 既存の `AI: ` プレフィックスと逐次 `process.stdout.write` の順序を壊さない。
-   - _Validation_: `src/tests/unit/interaction/chat.command.test.ts` で表示文言と呼び出し順を検証。
+2. [ ] **Step 2: session start/save/load/end を実装する**
+   - _Action_: `main.ts` に `session` サブコマンド群を追加し、開始・保存・読込・終了を操作可能にする。
+   - _Action_: 成功時に保存先/対象 session id を標準出力に明示する。
+   - _Validation_: `main.program` 系ユニットテストでコマンド登録と action 挙動を検証。
 
-3. [ ] **Step 3: F-002 受け入れテストの追加**
-   - _Action_: `src/tests/acceptance/features/F-002.streaming.acceptance.test.ts` を追加し、以下を検証。
-     - 完了前にチャンクが表示される。
-     - 実行中表示と完了表示がユーザー可視である。
-     - 重複表示せず順序が維持される。
-   - _Validation_: `npm test` で新規 acceptance を含めて成功。
+3. [ ] **Step 3: チャットと履歴永続化を接続する**
+   - _Action_: `chat.command.ts` でセッション履歴をロードして初期 `messages` に反映。
+   - _Action_: 各ターン完了時に user/assistant 発話をセッションへ保存。
+   - _Validation_: 連続2ターンで履歴が再利用されるテストを追加。
 
-4. [ ] **Step 4: 最終検証と差分確認**
-   - _Action_: 変更ファイルが計画内に限定されていることを確認。
-   - _Validation_: F-002 DoD との対応表をPR説明に転記できる粒度で確認。
+4. [ ] **Step 4: 最小コンテキスト管理（保持/破棄/要約）を追加する**
+   - _Action_: 保持件数ポリシー（過去Nターン）を導入し、投入メッセージを制限する。
+   - _Action_: 明示破棄（全破棄 or 範囲破棄）を `session` コマンドで提供。
+   - _Action_: 要約圧縮は「古い履歴を1メッセージへ要約」する最小実装に限定する。
+   - _Validation_: F-005 受け入れテストで保持/破棄/圧縮の反映を確認。
+
+5. [ ] **Step 5: 受け入れテストとドキュメントを整える**
+   - _Action_: `F-004`/`F-005` acceptance テストを追加。
+   - _Action_: README の `session` 操作例と制約（MVP）を更新。
+   - _Validation_: `npm test` 全体成功、DoD 対応を確認。
 
 ## 4. 検証プラン (Verification Plan)
 
 - 必須テスト:
   - `npm test -- src/tests/unit/application/run-chat.usecase.test.ts`
-  - `npm test -- src/tests/unit/interaction/chat.command.test.ts`
+  - `npm test -- src/tests/unit/application/main.program.test.ts`
+  - `npm test -- src/tests/acceptance/features/F-004.session.acceptance.test.ts`
+  - `npm test -- src/tests/acceptance/features/F-005.context.acceptance.test.ts`
+- 回帰確認:
+  - `npm test -- src/tests/acceptance/features/F-001.chat.acceptance.test.ts`
   - `npm test -- src/tests/acceptance/features/F-002.streaming.acceptance.test.ts`
-- 最終テスト:
+  - `npm test -- src/tests/acceptance/features/F-003.model-selection.acceptance.test.ts`
+- 最終確認:
   - `npm test`
 - 手動確認:
-  - `chat "hello"` 実行時に、応答本文の逐次表示に加えて実行中表示が見える。
-  - 応答終了時に完了が明示される（done表示または同等の完了サイン）。
-  - 応答テキストの表示順が入力順・生成順と一致する。
+  - `session start` → `chat` 実行 → `session save` → `session load` 後に文脈が再利用されること。
+  - コンテキスト破棄/要約操作後の次ターンで、反映された履歴のみ送信されること。
 
 ## 5. ガードレール (Guardrails for Coding Agent)
 
-- `doc/CURRENT_PLAN.md` に記載のないファイル変更は禁止する。
-- 実装中に仕様追加が必要になった場合は、コード変更前に本計画を更新して承認を得る。
-- 表示文言を変更する場合、対応するテスト期待値を同時更新し、意図をコメントまたはPR説明に残す。
-- 既存の逐次出力ロジックを破壊しないことを最優先とし、必要最小限の差分で実装する。
+- `doc/CURRENT_PLAN.md` に記載したファイル以外は原則変更しない。
+- 実装中に追加仕様が必要になった場合は、先に本計画を更新して承認を得る。
+- 既存 F-001/F-002/F-003 の振る舞い（逐次表示、モデル解決優先順、対話 UX）を壊さない。
+- 永続化フォーマット変更時は後方互換（既存 `session.json` 読み込み失敗時の安全側処理）を維持する。
+- 複雑化を避け、MVP では「最小機能で受け入れ条件を満たす」ことを優先する。

--- a/src/adapters/session/file-session-store.adapter.ts
+++ b/src/adapters/session/file-session-store.adapter.ts
@@ -1,33 +1,350 @@
-import * as fs from 'fs';
-import { promises as fsp } from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { SessionStorePort } from '../../ports/outbound/session-store.port';
+import * as fs from "fs";
+import { promises as fsp } from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  DEFAULT_SESSION_CONTEXT_POLICY,
+  isValidSessionId,
+  SessionRecord,
+  SESSION_ID_PATTERN,
+  SessionStorePort,
+} from "../../ports/outbound/session-store.port";
 
 interface SessionConfig {
   models?: Record<string, string>;
+  sessions?: Record<string, SessionRecord>;
 }
 
-const CONFIG_DIR = path.join(os.homedir(), '.multi-llm-agent-cli');
-const SESSION_FILE = path.join(CONFIG_DIR, 'session.json');
+function resolveConfigDir(): string {
+  const configured = process.env.MULTI_LLM_AGENT_CONFIG_DIR?.trim();
+  if (configured) {
+    return configured;
+  }
+  return path.join(os.homedir(), ".multi-llm-agent-cli");
+}
+
+const CONFIG_DIR = resolveConfigDir();
+const SESSION_FILE = path.join(CONFIG_DIR, "session.json");
+const SESSION_LOCK_FILE = path.join(CONFIG_DIR, "session.lock");
+const SESSION_FILE_MODE = 0o600;
+const SESSION_DIR_MODE = 0o700;
+const DEFAULT_LOCK_TIMEOUT_MS = 5000;
+const DEFAULT_LOCK_RETRY_DELAY_MS = 50;
+const DEFAULT_LOCK_STALE_MS = 60_000;
+
+function parsePositiveIntegerEnv(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+const LOCK_TIMEOUT_MS = parsePositiveIntegerEnv(
+  process.env.MULTI_LLM_SESSION_LOCK_TIMEOUT_MS,
+  DEFAULT_LOCK_TIMEOUT_MS,
+);
+const LOCK_RETRY_DELAY_MS = parsePositiveIntegerEnv(
+  process.env.MULTI_LLM_SESSION_LOCK_RETRY_DELAY_MS,
+  DEFAULT_LOCK_RETRY_DELAY_MS,
+);
+const LOCK_STALE_MS = parsePositiveIntegerEnv(
+  process.env.MULTI_LLM_SESSION_LOCK_STALE_MS,
+  DEFAULT_LOCK_STALE_MS,
+);
+
+interface LockMetadata {
+  pid: number;
+  createdAt: number;
+}
+
+function normalizeSession(
+  session: Partial<SessionRecord> | undefined,
+): SessionRecord {
+  return {
+    model: session?.model,
+    messages: Array.isArray(session?.messages) ? [...session.messages] : [],
+    summary: session?.summary,
+    policy: {
+      maxTurns:
+        typeof session?.policy?.maxTurns === "number" &&
+        session.policy.maxTurns >= 0
+          ? Math.floor(session.policy.maxTurns)
+          : DEFAULT_SESSION_CONTEXT_POLICY.maxTurns,
+      summaryEnabled:
+        typeof session?.policy?.summaryEnabled === "boolean"
+          ? session.policy.summaryEnabled
+          : DEFAULT_SESSION_CONTEXT_POLICY.summaryEnabled,
+    },
+    savedAt: session?.savedAt,
+    loadedAt: session?.loadedAt,
+    updatedAt: session?.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+async function safeChmod(targetPath: string, mode: number): Promise<void> {
+  try {
+    await fsp.chmod(targetPath, mode);
+  } catch {
+    // Keep storage best-effort across OS/filesystem types.
+  }
+}
+
+function validateSessionId(sessionId: string): void {
+  if (!isValidSessionId(sessionId)) {
+    throw new Error(`Invalid session id: ${sessionId}`);
+  }
+}
+
+function toSafeStringRecord(input: unknown): Record<string, string> {
+  const record = Object.create(null) as Record<string, string>;
+  if (!input || typeof input !== "object") {
+    return record;
+  }
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (!SESSION_ID_PATTERN.test(key) || typeof value !== "string") {
+      continue;
+    }
+    record[key] = value;
+  }
+  return record;
+}
+
+function toSafeSessionRecordMap(input: unknown): Record<string, SessionRecord> {
+  const record = Object.create(null) as Record<string, SessionRecord>;
+  if (!input || typeof input !== "object") {
+    return record;
+  }
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (!SESSION_ID_PATTERN.test(key) || !value || typeof value !== "object") {
+      continue;
+    }
+    record[key] = normalizeSession(value as Partial<SessionRecord>);
+  }
+  return record;
+}
+
+function normalizeConfig(config: SessionConfig): SessionConfig {
+  return {
+    models: toSafeStringRecord(config.models),
+    sessions: toSafeSessionRecordMap(config.sessions),
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export class FileSessionStoreAdapter implements SessionStorePort {
   async getModel(sessionId: string): Promise<string | undefined> {
-    const config = await this.readConfig();
-    return config.models?.[sessionId];
+    validateSessionId(sessionId);
+    const session = await this.getSession(sessionId);
+    return session?.model;
   }
 
   async setModel(sessionId: string, model: string): Promise<void> {
-    const config = await this.readConfig();
-    const models = config.models ?? {};
-    models[sessionId] = model;
+    validateSessionId(sessionId);
+    await this.withConfigLock(async () => {
+      const config = normalizeConfig(await this.readConfig());
+      const existing = config.sessions?.[sessionId]
+        ? normalizeSession(config.sessions[sessionId])
+        : config.models?.[sessionId]
+          ? normalizeSession({ model: config.models[sessionId] })
+          : undefined;
+      const session = normalizeSession({
+        ...existing,
+        model,
+        updatedAt: new Date().toISOString(),
+      });
+      await this.saveSessionUnlocked(config, sessionId, session);
+    });
+  }
 
+  async getSession(sessionId: string): Promise<SessionRecord | undefined> {
+    validateSessionId(sessionId);
+    const config = normalizeConfig(await this.readConfig());
+    const fromSessions = config.sessions?.[sessionId];
+    if (fromSessions) {
+      return normalizeSession(fromSessions);
+    }
+    const legacyModel = config.models?.[sessionId];
+    if (legacyModel) {
+      return normalizeSession({ model: legacyModel });
+    }
+    return undefined;
+  }
+
+  async saveSession(sessionId: string, session: SessionRecord): Promise<void> {
+    validateSessionId(sessionId);
+    await this.withConfigLock(async () => {
+      const config = normalizeConfig(await this.readConfig());
+      await this.saveSessionUnlocked(config, sessionId, session);
+    });
+  }
+
+  async endSession(sessionId: string): Promise<void> {
+    validateSessionId(sessionId);
+    await this.withConfigLock(async () => {
+      const config = normalizeConfig(await this.readConfig());
+      const sessions = config.sessions ?? Object.create(null);
+      const models = config.models ?? Object.create(null);
+      delete sessions[sessionId];
+      delete models[sessionId];
+      await this.writeConfig({ ...config, sessions, models });
+    });
+  }
+
+  private async saveSessionUnlocked(
+    config: SessionConfig,
+    sessionId: string,
+    session: SessionRecord,
+  ): Promise<void> {
+    const sessions = config.sessions ?? Object.create(null);
+    sessions[sessionId] = normalizeSession(session);
+    const models = config.models ?? Object.create(null);
+    if (session.model) {
+      models[sessionId] = session.model;
+    } else {
+      delete models[sessionId];
+    }
+
+    await this.writeConfig({ ...config, sessions, models });
+  }
+
+  private async withConfigLock<T>(action: () => Promise<T>): Promise<T> {
     await fsp.mkdir(CONFIG_DIR, { recursive: true });
-    await fsp.writeFile(
-      SESSION_FILE,
-      JSON.stringify({ ...config, models }, null, 2),
-      'utf-8',
-    );
+    await safeChmod(CONFIG_DIR, SESSION_DIR_MODE);
+    const startedAt = Date.now();
+    let handle: fs.promises.FileHandle | undefined;
+
+    while (!handle) {
+      try {
+        handle = await fsp.open(SESSION_LOCK_FILE, "wx", SESSION_FILE_MODE);
+        await handle.writeFile(
+          JSON.stringify({
+            pid: process.pid,
+            createdAt: Date.now(),
+          } satisfies LockMetadata),
+          "utf-8",
+        );
+        await handle.sync();
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "EEXIST") {
+          throw error;
+        }
+
+        const recovered = await this.tryRecoverStaleLock();
+        if (recovered) {
+          continue;
+        }
+
+        if (Date.now() - startedAt > LOCK_TIMEOUT_MS) {
+          throw new Error(
+            `Timed out waiting for session lock after ${LOCK_TIMEOUT_MS}ms. Please retry.`,
+          );
+        }
+        await sleep(LOCK_RETRY_DELAY_MS);
+      }
+    }
+
+    try {
+      return await action();
+    } finally {
+      await handle.close();
+      try {
+        await fsp.unlink(SESSION_LOCK_FILE);
+      } catch {
+        // Best effort unlock.
+      }
+    }
+  }
+
+  private async tryRecoverStaleLock(): Promise<boolean> {
+    try {
+      const raw = await fsp.readFile(SESSION_LOCK_FILE, "utf-8");
+      const metadata = this.parseLockMetadata(raw);
+      const now = Date.now();
+
+      let lockAgeMs: number;
+      if (metadata?.createdAt) {
+        lockAgeMs = now - metadata.createdAt;
+      } else {
+        const stat = await fsp.stat(SESSION_LOCK_FILE);
+        lockAgeMs = now - stat.mtimeMs;
+      }
+
+      if (lockAgeMs < LOCK_STALE_MS) {
+        return false;
+      }
+
+      if (metadata?.pid !== undefined && this.isProcessAlive(metadata.pid)) {
+        return false;
+      }
+
+      await fsp.unlink(SESSION_LOCK_FILE);
+      return true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  private parseLockMetadata(raw: string): LockMetadata | undefined {
+    try {
+      const parsed = JSON.parse(raw) as Partial<LockMetadata>;
+      if (
+        typeof parsed?.pid === "number" &&
+        Number.isInteger(parsed.pid) &&
+        parsed.pid > 0 &&
+        typeof parsed?.createdAt === "number" &&
+        Number.isFinite(parsed.createdAt) &&
+        parsed.createdAt > 0
+      ) {
+        return {
+          pid: parsed.pid,
+          createdAt: parsed.createdAt,
+        };
+      }
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ESRCH") {
+        return false;
+      }
+      // EPERM or unknown errors are treated as "alive" to avoid unsafe lock stealing.
+      return true;
+    }
+  }
+
+  private async writeConfig(config: SessionConfig): Promise<void> {
+    const tempFile = `${SESSION_FILE}.tmp-${process.pid}-${Date.now()}`;
+    const payload = JSON.stringify(config, null, 2);
+    await fsp.writeFile(tempFile, payload, {
+      encoding: "utf-8",
+      mode: SESSION_FILE_MODE,
+    });
+    await safeChmod(tempFile, SESSION_FILE_MODE);
+    await fsp.rename(tempFile, SESSION_FILE);
+    await safeChmod(SESSION_FILE, SESSION_FILE_MODE);
   }
 
   private async readConfig(): Promise<SessionConfig> {
@@ -36,9 +353,18 @@ export class FileSessionStoreAdapter implements SessionStorePort {
         return {};
       }
 
-      const raw = await fsp.readFile(SESSION_FILE, 'utf-8');
+      const raw = await fsp.readFile(SESSION_FILE, "utf-8");
       return JSON.parse(raw) as SessionConfig;
-    } catch {
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && fs.existsSync(SESSION_FILE)) {
+        const backupFile = `${SESSION_FILE}.corrupt-${Date.now()}`;
+        try {
+          await fsp.rename(SESSION_FILE, backupFile);
+        } catch {
+          // Keep best-effort fallback; an unreadable file should not break CLI startup.
+        }
+      }
       return {};
     }
   }

--- a/src/adapters/session/in-memory-session-store.adapter.ts
+++ b/src/adapters/session/in-memory-session-store.adapter.ts
@@ -1,13 +1,55 @@
-import { SessionStorePort } from '../../ports/outbound/session-store.port';
+import {
+  DEFAULT_SESSION_CONTEXT_POLICY,
+  isValidSessionId,
+  SessionRecord,
+  SessionStorePort,
+} from "../../ports/outbound/session-store.port";
+
+function cloneSession(session: SessionRecord): SessionRecord {
+  return JSON.parse(JSON.stringify(session)) as SessionRecord;
+}
+
+function validateSessionId(sessionId: string): void {
+  if (!isValidSessionId(sessionId)) {
+    throw new Error(`Invalid session id: ${sessionId}`);
+  }
+}
 
 export class InMemorySessionStoreAdapter implements SessionStorePort {
-  private readonly models = new Map<string, string>();
+  private readonly sessions = new Map<string, SessionRecord>();
 
   async getModel(sessionId: string): Promise<string | undefined> {
-    return this.models.get(sessionId);
+    validateSessionId(sessionId);
+    return this.sessions.get(sessionId)?.model;
   }
 
   async setModel(sessionId: string, model: string): Promise<void> {
-    this.models.set(sessionId, model);
+    validateSessionId(sessionId);
+    const existing = this.sessions.get(sessionId);
+    const next: SessionRecord = existing
+      ? { ...existing, model, updatedAt: new Date().toISOString() }
+      : {
+          model,
+          messages: [],
+          policy: { ...DEFAULT_SESSION_CONTEXT_POLICY },
+          updatedAt: new Date().toISOString(),
+        };
+    this.sessions.set(sessionId, next);
+  }
+
+  async getSession(sessionId: string): Promise<SessionRecord | undefined> {
+    validateSessionId(sessionId);
+    const session = this.sessions.get(sessionId);
+    return session ? cloneSession(session) : undefined;
+  }
+
+  async saveSession(sessionId: string, session: SessionRecord): Promise<void> {
+    validateSessionId(sessionId);
+    this.sessions.set(sessionId, cloneSession(session));
+  }
+
+  async endSession(sessionId: string): Promise<void> {
+    validateSessionId(sessionId);
+    this.sessions.delete(sessionId);
   }
 }

--- a/src/application/chat/run-chat.usecase.ts
+++ b/src/application/chat/run-chat.usecase.ts
@@ -1,7 +1,12 @@
-import { ResolveModelUseCase } from '../model-endpoint/resolve-model.usecase';
-import { LlmClientPort } from '../../ports/outbound/llm-client.port';
-import { SessionStorePort } from '../../ports/outbound/session-store.port';
-import { ChatMessage, ModelResolutionSource } from '../../shared/types/chat';
+import { ResolveModelUseCase } from "../model-endpoint/resolve-model.usecase";
+import { LlmClientPort } from "../../ports/outbound/llm-client.port";
+import {
+  DEFAULT_SESSION_CONTEXT_POLICY,
+  SessionContextPolicy,
+  SessionRecord,
+  SessionStorePort,
+} from "../../ports/outbound/session-store.port";
+import { ChatMessage, ModelResolutionSource } from "../../shared/types/chat";
 
 export interface ChatSessionStartInput {
   sessionId: string;
@@ -16,12 +21,86 @@ export interface ChatSessionStartSuccess {
 
 export interface ChatSessionStartFailure {
   ok: false;
-  code: 'MODEL_NOT_FOUND';
+  code: "MODEL_NOT_FOUND";
   model: string;
   candidates: string[];
 }
 
-export type ChatSessionStartResult = ChatSessionStartSuccess | ChatSessionStartFailure;
+export type ChatSessionStartResult =
+  | ChatSessionStartSuccess
+  | ChatSessionStartFailure;
+
+export interface ChatContextSnapshot {
+  messages: ChatMessage[];
+  policy: SessionContextPolicy;
+}
+
+export interface ChatSessionLoadResult {
+  session: SessionRecord;
+  restoredMessageCount: number;
+  restoredSummary: boolean;
+}
+
+export class SessionNotFoundError extends Error {
+  constructor(sessionId: string) {
+    super(`Session '${sessionId}' was not found.`);
+    this.name = "SessionNotFoundError";
+  }
+}
+
+function normalizeMaxTurns(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    return DEFAULT_SESSION_CONTEXT_POLICY.maxTurns;
+  }
+  return Math.floor(value);
+}
+
+function compactText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncateText(value: string, maxChars: number): string {
+  if (maxChars <= 0) {
+    return "";
+  }
+  if (value.length <= maxChars) {
+    return value;
+  }
+  if (maxChars <= 3) {
+    return ".".repeat(maxChars);
+  }
+  return `${value.slice(0, maxChars - 3)}...`;
+}
+
+function buildMergedSummary(
+  previousSummary: string,
+  oldMessageSummary: string,
+  maxChars = 500,
+): string {
+  const next = compactText(oldMessageSummary);
+  const previous = compactText(previousSummary);
+  if (!previous) {
+    return truncateText(next, maxChars);
+  }
+  if (!next) {
+    return truncateText(`previous: ${previous}`, maxChars);
+  }
+
+  const separator = " | previous: ";
+  const budgetForNext = Math.min(
+    next.length,
+    Math.max(120, Math.floor(maxChars * 0.65)),
+  );
+  const budgetForPrevious = Math.max(
+    0,
+    maxChars - separator.length - budgetForNext,
+  );
+  const merged = `${truncateText(next, budgetForNext)}${separator}${truncateText(
+    previous,
+    budgetForPrevious,
+  )}`;
+  return truncateText(merged, maxChars);
+}
 
 export class RunChatUseCase {
   constructor(
@@ -30,7 +109,9 @@ export class RunChatUseCase {
     private readonly sessionStore: SessionStorePort,
   ) {}
 
-  async startSession(input: ChatSessionStartInput): Promise<ChatSessionStartResult> {
+  async startSession(
+    input: ChatSessionStartInput,
+  ): Promise<ChatSessionStartResult> {
     const resolved = await this.resolver.execute({
       sessionId: input.sessionId,
       cliModel: input.cliModel,
@@ -41,13 +122,18 @@ export class RunChatUseCase {
     if (!availableModelNames.includes(resolved.model)) {
       return {
         ok: false,
-        code: 'MODEL_NOT_FOUND',
+        code: "MODEL_NOT_FOUND",
         model: resolved.model,
         candidates: availableModelNames,
       };
     }
 
-    await this.sessionStore.setModel(input.sessionId, resolved.model);
+    const session = await this.getOrCreateSession(input.sessionId);
+    await this.writeSession(input.sessionId, {
+      ...session,
+      model: resolved.model,
+      updatedAt: new Date().toISOString(),
+    });
     return {
       ok: true,
       model: resolved.model,
@@ -55,7 +141,168 @@ export class RunChatUseCase {
     };
   }
 
-  async *runTurn(model: string, messages: ChatMessage[]): AsyncGenerator<string> {
+  async loadContext(sessionId: string): Promise<ChatContextSnapshot> {
+    const session = await this.requireExistingSession(sessionId);
+    const maxMessages = session.policy.maxTurns * 2;
+    const recentMessages =
+      maxMessages > 0 ? session.messages.slice(-maxMessages) : [];
+    const messages: ChatMessage[] = [...recentMessages];
+    if (session.summary && session.summary.trim().length > 0) {
+      messages.unshift({
+        role: "assistant",
+        content: `Context summary (untrusted): ${session.summary}`,
+      });
+    }
+
+    return {
+      messages,
+      policy: session.policy,
+    };
+  }
+
+  async saveSession(sessionId: string): Promise<SessionRecord> {
+    const session = await this.requireExistingSession(sessionId);
+    const updated: SessionRecord = {
+      ...session,
+      savedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await this.writeSession(sessionId, updated);
+    return updated;
+  }
+
+  async loadSession(sessionId: string): Promise<ChatSessionLoadResult> {
+    const session = await this.requireExistingSession(sessionId);
+    const now = new Date().toISOString();
+    const updated: SessionRecord = {
+      ...session,
+      loadedAt: now,
+      updatedAt: now,
+    };
+    await this.writeSession(sessionId, updated);
+    return {
+      session: updated,
+      restoredMessageCount: updated.messages.length,
+      restoredSummary: Boolean(updated.summary && updated.summary.trim()),
+    };
+  }
+
+  async getSession(sessionId: string): Promise<SessionRecord | undefined> {
+    if (this.sessionStore.getSession) {
+      return this.sessionStore.getSession(sessionId);
+    }
+
+    const model = await this.sessionStore.getModel(sessionId);
+    if (!model) {
+      return undefined;
+    }
+    return this.createDefaultSession(model);
+  }
+
+  async endSession(sessionId: string): Promise<void> {
+    if (this.sessionStore.endSession) {
+      await this.sessionStore.endSession(sessionId);
+      return;
+    }
+    await this.sessionStore.setModel(sessionId, "");
+  }
+
+  async setContextPolicy(
+    sessionId: string,
+    policyPatch: Partial<SessionContextPolicy>,
+  ): Promise<SessionRecord> {
+    const session = await this.requireExistingSession(sessionId);
+    const nextPolicy: SessionContextPolicy = {
+      maxTurns:
+        policyPatch.maxTurns === undefined
+          ? session.policy.maxTurns
+          : normalizeMaxTurns(policyPatch.maxTurns),
+      summaryEnabled:
+        policyPatch.summaryEnabled === undefined
+          ? session.policy.summaryEnabled
+          : policyPatch.summaryEnabled,
+    };
+    const updated = {
+      ...session,
+      policy: nextPolicy,
+      updatedAt: new Date().toISOString(),
+    };
+    await this.writeSession(sessionId, updated);
+    return updated;
+  }
+
+  async clearContext(sessionId: string, keepTurns = 0): Promise<SessionRecord> {
+    const session = await this.requireExistingSession(sessionId);
+    const keepMessages = Math.max(0, Math.floor(keepTurns)) * 2;
+    const recent =
+      keepMessages > 0 ? session.messages.slice(-keepMessages) : [];
+    const updated: SessionRecord = {
+      ...session,
+      messages: recent,
+      summary: undefined,
+      updatedAt: new Date().toISOString(),
+    };
+    await this.writeSession(sessionId, updated);
+    return updated;
+  }
+
+  async summarizeContext(sessionId: string): Promise<SessionRecord> {
+    const session = await this.requireExistingSession(sessionId);
+    const keepMessages = session.policy.maxTurns * 2;
+    if (session.messages.length <= keepMessages) {
+      return session;
+    }
+
+    const oldMessages = session.messages.slice(
+      0,
+      session.messages.length - keepMessages,
+    );
+    const recentMessages =
+      keepMessages > 0 ? session.messages.slice(-keepMessages) : [];
+    const oldMessageSummary = oldMessages
+      .map((m) => `${m.role}: ${compactText(m.content)}`)
+      .join(" | ");
+    const summary = buildMergedSummary(
+      session.summary ?? "",
+      oldMessageSummary,
+    );
+
+    const updated: SessionRecord = {
+      ...session,
+      summary,
+      messages: recentMessages,
+      updatedAt: new Date().toISOString(),
+    };
+    await this.writeSession(sessionId, updated);
+    return updated;
+  }
+
+  async recordTurn(
+    sessionId: string,
+    userInput: string,
+    assistantResponse: string,
+  ): Promise<void> {
+    const session = await this.requireExistingSession(sessionId);
+    const nextMessages = [
+      ...session.messages,
+      { role: "user", content: userInput } as ChatMessage,
+      { role: "assistant", content: assistantResponse } as ChatMessage,
+    ];
+    await this.writeSession(sessionId, {
+      ...session,
+      messages: nextMessages,
+      updatedAt: new Date().toISOString(),
+    });
+
+    if (session.policy.summaryEnabled) {
+      await this.summarizeContext(sessionId);
+    }
+  }
+
+  async *runTurn(
+    model: string,
+    messages: ChatMessage[],
+  ): AsyncGenerator<string> {
     for await (const chunk of this.llmClient.chat(model, messages)) {
       if (chunk.content) {
         yield chunk.content;
@@ -63,6 +310,62 @@ export class RunChatUseCase {
       if (chunk.done) {
         return;
       }
+    }
+  }
+
+  private createDefaultSession(model?: string): SessionRecord {
+    return {
+      model,
+      messages: [],
+      policy: { ...DEFAULT_SESSION_CONTEXT_POLICY },
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  private async getOrCreateSession(sessionId: string): Promise<SessionRecord> {
+    const existing = await this.getSession(sessionId);
+    if (existing) {
+      return {
+        ...existing,
+        policy: {
+          maxTurns: normalizeMaxTurns(existing.policy.maxTurns),
+          summaryEnabled: existing.policy.summaryEnabled,
+        },
+      };
+    }
+
+    const created = this.createDefaultSession();
+    await this.writeSession(sessionId, created);
+    return created;
+  }
+
+  private async requireExistingSession(
+    sessionId: string,
+  ): Promise<SessionRecord> {
+    const existing = await this.getSession(sessionId);
+    if (!existing) {
+      throw new SessionNotFoundError(sessionId);
+    }
+    return {
+      ...existing,
+      policy: {
+        maxTurns: normalizeMaxTurns(existing.policy.maxTurns),
+        summaryEnabled: existing.policy.summaryEnabled,
+      },
+    };
+  }
+
+  private async writeSession(
+    sessionId: string,
+    session: SessionRecord,
+  ): Promise<void> {
+    if (this.sessionStore.saveSession) {
+      await this.sessionStore.saveSession(sessionId, session);
+      return;
+    }
+
+    if (session.model) {
+      await this.sessionStore.setModel(sessionId, session.model);
     }
   }
 }

--- a/src/application/model-endpoint/resolve-model.usecase.ts
+++ b/src/application/model-endpoint/resolve-model.usecase.ts
@@ -1,7 +1,7 @@
-import { resolveModelByPriority } from '../../domain/model-endpoint/services/model-resolution-policy';
-import { ConfigPort } from '../../ports/outbound/config.port';
-import { SessionStorePort } from '../../ports/outbound/session-store.port';
-import { ModelResolutionSource } from '../../shared/types/chat';
+import { resolveModelByPriority } from "../../domain/model-endpoint/services/model-resolution-policy";
+import { ConfigPort } from "../../ports/outbound/config.port";
+import { SessionStorePort } from "../../ports/outbound/session-store.port";
+import { ModelResolutionSource } from "../../shared/types/chat";
 
 export interface ResolveModelInput {
   sessionId: string;
@@ -20,9 +20,16 @@ export class ResolveModelUseCase {
   ) {}
 
   async execute(input: ResolveModelInput): Promise<ResolveModelOutput> {
+    const defaultModelPromise = this.config.getDefaultModel();
+    const sessionModelPromise = this.sessionStore.getSession
+      ? this.sessionStore
+          .getSession(input.sessionId)
+          .then((session) => session?.model)
+      : this.sessionStore.getModel(input.sessionId);
+
     const [defaultModel, sessionModel] = await Promise.all([
-      this.config.getDefaultModel(),
-      this.sessionStore.getModel(input.sessionId),
+      defaultModelPromise,
+      sessionModelPromise,
     ]);
 
     return resolveModelByPriority({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
 import { Command } from "commander";
 import { randomUUID } from "crypto";
+import * as os from "os";
+import * as path from "path";
 import { RunChatUseCase } from "./application/chat/run-chat.usecase";
 import { ResolveModelUseCase } from "./application/model-endpoint/resolve-model.usecase";
 import { FileConfigAdapter } from "./adapters/config/file-config.adapter";
@@ -7,9 +9,27 @@ import { OllamaClientAdapter } from "./adapters/ollama/ollama-client.adapter";
 import { InMemorySessionStoreAdapter } from "./adapters/session/in-memory-session-store.adapter";
 import { FileSessionStoreAdapter } from "./adapters/session/file-session-store.adapter";
 import { runChatCommand } from "./interaction/cli/commands/chat.command";
+import {
+  ChatEventLogEntry,
+  writeChatEventLog,
+} from "./operations/logging/chat-event-logger";
 import { LlmClientPort } from "./ports/outbound/llm-client.port";
 import { ConfigPort } from "./ports/outbound/config.port";
 import { SessionStorePort } from "./ports/outbound/session-store.port";
+
+function parseNonNegativeInteger(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`非負の整数を指定してください: ${value}`);
+  }
+  return Math.floor(parsed);
+}
+
+const SESSION_STORAGE_PATH = path.join(
+  process.env.MULTI_LLM_AGENT_CONFIG_DIR?.trim() ||
+    path.join(os.homedir(), ".multi-llm-agent-cli"),
+  "session.json",
+);
 
 export function createProgram(deps?: {
   useCase?: RunChatUseCase;
@@ -27,6 +47,22 @@ export function createProgram(deps?: {
   const resolver = new ResolveModelUseCase(config, sessionStore);
   const useCase =
     deps?.useCase ?? new RunChatUseCase(resolver, llmClient, sessionStore);
+  const logSessionEvent = async (
+    enabled: boolean,
+    entry: Omit<ChatEventLogEntry, "timestamp">,
+  ): Promise<void> => {
+    if (!enabled) {
+      return;
+    }
+    try {
+      await writeChatEventLog({
+        ...entry,
+        timestamp: new Date().toISOString(),
+      });
+    } catch {
+      // Logging must never break command execution.
+    }
+  };
 
   const program = new Command();
 
@@ -110,6 +146,324 @@ export function createProgram(deps?: {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`モデル設定に失敗しました: ${message}`);
+      }
+    });
+
+  const sessionCommand = program
+    .command("session")
+    .description("Session and context operations.");
+
+  sessionCommand
+    .command("start [session_id]")
+    .description("Start a session.")
+    .option("-m, --model <model_name>", "Model name for this session")
+    .option(
+      "--max-turns <n>",
+      "Max turns to keep in prompt context",
+      parseNonNegativeInteger,
+    )
+    .option("--summary", "Enable automatic context summarization")
+    .option(
+      "--log-events",
+      "Enable local session/context event logging (masked + rotated)",
+    )
+    .action(
+      async (
+        sessionId: string | undefined,
+        options: {
+          model?: string;
+          maxTurns?: number;
+          summary?: boolean;
+          logEvents?: boolean;
+        },
+      ) => {
+        const targetSessionId = sessionId ?? `session-${randomUUID()}`;
+        try {
+          const started = await useCase.startSession({
+            sessionId: targetSessionId,
+            cliModel: options.model,
+          });
+          if (!started.ok) {
+            console.error(
+              `エラー: モデル '${started.model}' は存在しません。候補: ${started.candidates.join(
+                ", ",
+              )}`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          const policyUpdated = await useCase.setContextPolicy(
+            targetSessionId,
+            {
+              maxTurns: options.maxTurns,
+              summaryEnabled:
+                options.summary === undefined ? undefined : options.summary,
+            },
+          );
+          console.log(`セッションを開始しました: ${targetSessionId}`);
+          console.log(
+            `model=${started.model}, keep_turns=${policyUpdated.policy.maxTurns}, summary=${
+              policyUpdated.policy.summaryEnabled ? "on" : "off"
+            }`,
+          );
+          await logSessionEvent(Boolean(options.logEvents), {
+            session_id: targetSessionId,
+            event_type: "session_start",
+            model: started.model,
+            resolution_source: started.source,
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          console.error(`セッション開始に失敗しました: ${message}`);
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  sessionCommand
+    .command("save <session_id>")
+    .description("Persist session snapshot metadata.")
+    .option(
+      "--log-events",
+      "Enable local session/context event logging (masked + rotated)",
+    )
+    .action(async (sessionId: string, options: { logEvents?: boolean }) => {
+      try {
+        const saved = await useCase.saveSession(sessionId);
+        console.log(
+          `セッションを保存しました: ${sessionId} (saved_at=${saved.savedAt}, path=${SESSION_STORAGE_PATH})`,
+        );
+        await logSessionEvent(Boolean(options.logEvents), {
+          session_id: sessionId,
+          event_type: "session_save",
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`セッション保存に失敗しました: ${message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  sessionCommand
+    .command("load <session_id>")
+    .description("Load a session snapshot for subsequent chat reuse.")
+    .option(
+      "--log-events",
+      "Enable local session/context event logging (masked + rotated)",
+    )
+    .action(async (sessionId: string, options: { logEvents?: boolean }) => {
+      try {
+        const loaded = await useCase.loadSession(sessionId);
+        const session = loaded.session;
+        console.log(
+          `セッションを読み込みました: ${sessionId} (path=${SESSION_STORAGE_PATH})`,
+        );
+        console.log(`model=${session.model ?? "(unset)"}`);
+        console.log(`restored_messages=${loaded.restoredMessageCount}`);
+        console.log(
+          `restored_summary=${loaded.restoredSummary ? "yes" : "no"}`,
+        );
+        console.log(
+          `context: keep_turns=${session.policy.maxTurns}, summary=${
+            session.policy.summaryEnabled ? "on" : "off"
+          }`,
+        );
+        console.log(`loaded_at=${session.loadedAt ?? "(unset)"}`);
+        await logSessionEvent(Boolean(options.logEvents), {
+          session_id: sessionId,
+          event_type: "session_load",
+          model: session.model,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`セッション読込に失敗しました: ${message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  sessionCommand
+    .command("end <session_id>")
+    .description("End a session and remove stored data.")
+    .option(
+      "--log-events",
+      "Enable local session/context event logging (masked + rotated)",
+    )
+    .action(async (sessionId: string, options: { logEvents?: boolean }) => {
+      try {
+        await useCase.endSession(sessionId);
+        console.log(`セッションを終了しました: ${sessionId}`);
+        await logSessionEvent(Boolean(options.logEvents), {
+          session_id: sessionId,
+          event_type: "session_end",
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`セッション終了に失敗しました: ${message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  const contextCommand = sessionCommand
+    .command("context")
+    .description("Context controls for a session.");
+
+  contextCommand
+    .command("show <session_id>")
+    .description("Show context policy and current usage.")
+    .option(
+      "--log-events",
+      "Enable local session/context event logging (masked + rotated)",
+    )
+    .action(async (sessionId: string, options: { logEvents?: boolean }) => {
+      try {
+        const session = await useCase.getSession(sessionId);
+        if (!session) {
+          console.error(`セッション '${sessionId}' は存在しません。`);
+          process.exitCode = 1;
+          return;
+        }
+        console.log(`session=${sessionId}`);
+        console.log(
+          `policy: keep_turns=${session.policy.maxTurns}, summary=${
+            session.policy.summaryEnabled ? "on" : "off"
+          }`,
+        );
+        console.log(`history_messages=${session.messages.length}`);
+        console.log(`summary=${session.summary ? "present" : "none"}`);
+        await logSessionEvent(Boolean(options.logEvents), {
+          session_id: sessionId,
+          event_type: "context_show",
+          model: session.model,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`コンテキスト表示に失敗しました: ${message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  contextCommand
+    .command("set <session_id>")
+    .description("Set context policy.")
+    .option(
+      "--max-turns <n>",
+      "Max turns to keep in prompt context",
+      parseNonNegativeInteger,
+    )
+    .option("--summary <on|off>", "Enable or disable automatic summarization")
+    .option(
+      "--log-events",
+      "Enable local session/context event logging (masked + rotated)",
+    )
+    .action(
+      async (
+        sessionId: string,
+        options: { maxTurns?: number; summary?: string; logEvents?: boolean },
+      ) => {
+        try {
+          const summaryValue =
+            options.summary === undefined
+              ? undefined
+              : options.summary.toLowerCase() === "on";
+          if (
+            options.summary !== undefined &&
+            !["on", "off"].includes(options.summary.toLowerCase())
+          ) {
+            console.error(
+              "`--summary` には `on` か `off` を指定してください。",
+            );
+            process.exitCode = 1;
+            return;
+          }
+          const session = await useCase.setContextPolicy(sessionId, {
+            maxTurns: options.maxTurns,
+            summaryEnabled: summaryValue,
+          });
+          console.log(
+            `context更新: keep_turns=${session.policy.maxTurns}, summary=${
+              session.policy.summaryEnabled ? "on" : "off"
+            }`,
+          );
+          await logSessionEvent(Boolean(options.logEvents), {
+            session_id: sessionId,
+            event_type: "context_set",
+            model: session.model,
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          console.error(`コンテキスト更新に失敗しました: ${message}`);
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  contextCommand
+    .command("clear <session_id>")
+    .description("Discard old context history.")
+    .option(
+      "--keep-turns <n>",
+      "Keep the latest N turns",
+      parseNonNegativeInteger,
+      0,
+    )
+    .option(
+      "--log-events",
+      "Enable local session/context event logging (masked + rotated)",
+    )
+    .action(
+      async (
+        sessionId: string,
+        options: { keepTurns: number; logEvents?: boolean },
+      ) => {
+        try {
+          const session = await useCase.clearContext(
+            sessionId,
+            options.keepTurns,
+          );
+          console.log(
+            `context破棄完了: kept_turns=${options.keepTurns}, messages=${session.messages.length}`,
+          );
+          await logSessionEvent(Boolean(options.logEvents), {
+            session_id: sessionId,
+            event_type: "context_clear",
+            model: session.model,
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          console.error(`コンテキスト破棄に失敗しました: ${message}`);
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  contextCommand
+    .command("summarize <session_id>")
+    .description("Summarize and compact old context history.")
+    .option(
+      "--log-events",
+      "Enable local session/context event logging (masked + rotated)",
+    )
+    .action(async (sessionId: string, options: { logEvents?: boolean }) => {
+      try {
+        const session = await useCase.summarizeContext(sessionId);
+        console.log(
+          `context要約完了: messages=${session.messages.length}, summary=${
+            session.summary ? "present" : "none"
+          }`,
+        );
+        await logSessionEvent(Boolean(options.logEvents), {
+          session_id: sessionId,
+          event_type: "context_summarize",
+          model: session.model,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`コンテキスト要約に失敗しました: ${message}`);
+        process.exitCode = 1;
       }
     });
 

--- a/src/operations/logging/chat-event-logger.ts
+++ b/src/operations/logging/chat-event-logger.ts
@@ -10,9 +10,19 @@ const DEFAULT_MAX_LOG_BYTES = 1024 * 1024;
 export interface ChatEventLogEntry {
   timestamp: string;
   session_id: string;
-  event_type: "session_start" | "turn_completed" | "turn_failed";
-  model: string;
-  resolution_source: ModelResolutionSource;
+  event_type:
+    | "session_start"
+    | "session_save"
+    | "session_load"
+    | "session_end"
+    | "context_show"
+    | "context_set"
+    | "context_clear"
+    | "context_summarize"
+    | "turn_completed"
+    | "turn_failed";
+  model?: string;
+  resolution_source?: ModelResolutionSource;
   user_input?: string;
   assistant_response?: string;
   duration_ms?: number;

--- a/src/ports/outbound/session-store.port.ts
+++ b/src/ports/outbound/session-store.port.ts
@@ -1,4 +1,41 @@
+import { ChatMessage } from "../../shared/types/chat";
+
+export interface SessionContextPolicy {
+  maxTurns: number;
+  summaryEnabled: boolean;
+}
+
+export interface SessionRecord {
+  model?: string;
+  messages: ChatMessage[];
+  summary?: string;
+  policy: SessionContextPolicy;
+  savedAt?: string;
+  loadedAt?: string;
+  updatedAt: string;
+}
+
+export const DEFAULT_SESSION_CONTEXT_POLICY: SessionContextPolicy = {
+  maxTurns: 10,
+  summaryEnabled: false,
+};
+
+export const SESSION_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+export const SESSION_ID_MAX_LENGTH = 256;
+
+export function isValidSessionId(sessionId: string): boolean {
+  return (
+    typeof sessionId === "string" &&
+    sessionId.length > 0 &&
+    sessionId.length <= SESSION_ID_MAX_LENGTH &&
+    SESSION_ID_PATTERN.test(sessionId)
+  );
+}
+
 export interface SessionStorePort {
   getModel(sessionId: string): Promise<string | undefined>;
   setModel(sessionId: string, model: string): Promise<void>;
+  getSession?(sessionId: string): Promise<SessionRecord | undefined>;
+  saveSession?(sessionId: string, session: SessionRecord): Promise<void>;
+  endSession?(sessionId: string): Promise<void>;
 }

--- a/src/tests/acceptance/features/F-001.chat.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-001.chat.acceptance.test.ts
@@ -12,6 +12,13 @@ function createMockUseCase(startModel = "test-model") {
       yield "hello";
       yield " world";
     }),
+    loadContext: jest
+      .fn()
+      .mockResolvedValue({
+        messages: [],
+        policy: { maxTurns: 10, summaryEnabled: false },
+      }),
+    recordTurn: jest.fn().mockResolvedValue(undefined),
   } as unknown as RunChatUseCase;
 }
 
@@ -62,6 +69,13 @@ describe("F-001 CLI Chat acceptance", () => {
         model: "missing",
         candidates: ["model-a"],
       }),
+      loadContext: jest
+        .fn()
+        .mockResolvedValue({
+          messages: [],
+          policy: { maxTurns: 10, summaryEnabled: false },
+        }),
+      recordTurn: jest.fn().mockResolvedValue(undefined),
       runTurn: jest.fn(),
     } as unknown as RunChatUseCase;
 

--- a/src/tests/acceptance/features/F-002.streaming.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-002.streaming.acceptance.test.ts
@@ -13,6 +13,13 @@ function createMockUseCase() {
       yield "-second";
       yield "-third";
     }),
+    loadContext: jest
+      .fn()
+      .mockResolvedValue({
+        messages: [],
+        policy: { maxTurns: 10, summaryEnabled: false },
+      }),
+    recordTurn: jest.fn().mockResolvedValue(undefined),
   } as unknown as RunChatUseCase;
 }
 

--- a/src/tests/acceptance/features/F-004.session.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-004.session.acceptance.test.ts
@@ -1,0 +1,77 @@
+import { runChatCommand } from "../../../interaction/cli/commands/chat.command";
+import { RunChatUseCase } from "../../../application/chat/run-chat.usecase";
+import { ResolveModelUseCase } from "../../../application/model-endpoint/resolve-model.usecase";
+import { InMemorySessionStoreAdapter } from "../../../adapters/session/in-memory-session-store.adapter";
+import { ConfigPort } from "../../../ports/outbound/config.port";
+import {
+  LlmClientPort,
+  ModelSummary,
+} from "../../../ports/outbound/llm-client.port";
+import { ChatChunk, ChatMessage } from "../../../shared/types/chat";
+
+class FixedConfig implements ConfigPort {
+  async getDefaultModel(): Promise<string> {
+    return "model-a";
+  }
+
+  async setDefaultModel(_model: string): Promise<void> {}
+}
+
+class SpyLlmClient implements LlmClientPort {
+  public readonly calls: ChatMessage[][] = [];
+
+  async listModels(): Promise<ModelSummary[]> {
+    return [{ name: "model-a" }];
+  }
+
+  async *chat(
+    _model: string,
+    messages: ChatMessage[],
+  ): AsyncGenerator<ChatChunk> {
+    this.calls.push(messages);
+    yield { content: "ok", done: false };
+    yield { content: "", done: true };
+  }
+}
+
+describe("F-004 Session Management acceptance", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("reuses context after save/load through the same session id", async () => {
+    const store = new InMemorySessionStoreAdapter();
+    const llm = new SpyLlmClient();
+    const resolver = new ResolveModelUseCase(new FixedConfig(), store);
+    const useCase = new RunChatUseCase(resolver, llm, store);
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runChatCommand(
+      { prompt: "first", sessionId: "s-1" },
+      { useCase, createSessionId: () => "unused" },
+    );
+
+    await useCase.saveSession("s-1");
+    const loaded = await useCase.loadSession("s-1");
+    expect(loaded.restoredMessageCount).toBe(2);
+    expect(loaded.restoredSummary).toBe(false);
+
+    const useCaseAfterLoad = new RunChatUseCase(resolver, llm, store);
+    await runChatCommand(
+      { prompt: "second", sessionId: "s-1" },
+      { useCase: useCaseAfterLoad, createSessionId: () => "unused" },
+    );
+
+    expect(llm.calls).toHaveLength(2);
+    expect(llm.calls[1]).toEqual(
+      expect.arrayContaining([
+        { role: "user", content: "first" },
+        { role: "assistant", content: "ok" },
+        { role: "user", content: "second" },
+      ]),
+    );
+  });
+});

--- a/src/tests/acceptance/features/F-005.context.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-005.context.acceptance.test.ts
@@ -1,0 +1,78 @@
+import { RunChatUseCase } from "../../../application/chat/run-chat.usecase";
+import { ResolveModelUseCase } from "../../../application/model-endpoint/resolve-model.usecase";
+import { InMemorySessionStoreAdapter } from "../../../adapters/session/in-memory-session-store.adapter";
+import { ConfigPort } from "../../../ports/outbound/config.port";
+import {
+  LlmClientPort,
+  ModelSummary,
+} from "../../../ports/outbound/llm-client.port";
+import { ChatChunk, ChatMessage } from "../../../shared/types/chat";
+
+class FixedConfig implements ConfigPort {
+  async getDefaultModel(): Promise<string> {
+    return "model-a";
+  }
+
+  async setDefaultModel(_model: string): Promise<void> {}
+}
+
+class NoopLlmClient implements LlmClientPort {
+  async listModels(): Promise<ModelSummary[]> {
+    return [{ name: "model-a" }];
+  }
+
+  async *chat(
+    _model: string,
+    _messages: ChatMessage[],
+  ): AsyncGenerator<ChatChunk> {
+    yield { content: "ok", done: true };
+  }
+}
+
+describe("F-005 Context Management acceptance", () => {
+  it("applies keep/discard/summarize controls to the next context", async () => {
+    const store = new InMemorySessionStoreAdapter();
+    const useCase = new RunChatUseCase(
+      new ResolveModelUseCase(new FixedConfig(), store),
+      new NoopLlmClient(),
+      store,
+    );
+
+    await useCase.startSession({ sessionId: "s-1" });
+    await useCase.recordTurn("s-1", "u1", "a1");
+    await useCase.recordTurn("s-1", "u2", "a2");
+    await useCase.recordTurn("s-1", "u3", "a3");
+
+    await useCase.setContextPolicy("s-1", {
+      maxTurns: 1,
+      summaryEnabled: false,
+    });
+    const kept = await useCase.loadContext("s-1");
+    expect(kept.messages).toEqual([
+      { role: "user", content: "u3" },
+      { role: "assistant", content: "a3" },
+    ]);
+
+    await useCase.clearContext("s-1", 0);
+    const cleared = await useCase.loadContext("s-1");
+    expect(cleared.messages).toEqual([]);
+
+    await useCase.recordTurn("s-1", "u4", "a4");
+    await useCase.recordTurn("s-1", "u5", "a5");
+    await useCase.recordTurn("s-1", "u6", "a6");
+    await useCase.setContextPolicy("s-1", {
+      maxTurns: 1,
+      summaryEnabled: true,
+    });
+    await useCase.summarizeContext("s-1");
+
+    const summarized = await useCase.loadContext("s-1");
+    expect(summarized.messages[0]?.role).toBe("assistant");
+    expect(summarized.messages).toEqual(
+      expect.arrayContaining([
+        { role: "user", content: "u6" },
+        { role: "assistant", content: "a6" },
+      ]),
+    );
+  });
+});

--- a/src/tests/unit/adapters/file-session-store.adapter.test.ts
+++ b/src/tests/unit/adapters/file-session-store.adapter.test.ts
@@ -1,0 +1,129 @@
+import { promises as fsp } from "fs";
+import * as os from "os";
+import * as path from "path";
+
+async function withTempHome(
+  run: (tempHome: string) => Promise<void>,
+): Promise<void> {
+  const tempHome = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "mla-session-store-"),
+  );
+  const previousConfigDir = process.env.MULTI_LLM_AGENT_CONFIG_DIR;
+  const previousLockTimeout = process.env.MULTI_LLM_SESSION_LOCK_TIMEOUT_MS;
+  const previousLockRetry = process.env.MULTI_LLM_SESSION_LOCK_RETRY_DELAY_MS;
+  const previousLockStale = process.env.MULTI_LLM_SESSION_LOCK_STALE_MS;
+  process.env.MULTI_LLM_AGENT_CONFIG_DIR = path.join(
+    tempHome,
+    ".multi-llm-agent-cli",
+  );
+  jest.resetModules();
+
+  try {
+    await run(tempHome);
+  } finally {
+    if (previousConfigDir === undefined) {
+      delete process.env.MULTI_LLM_AGENT_CONFIG_DIR;
+    } else {
+      process.env.MULTI_LLM_AGENT_CONFIG_DIR = previousConfigDir;
+    }
+    if (previousLockTimeout === undefined) {
+      delete process.env.MULTI_LLM_SESSION_LOCK_TIMEOUT_MS;
+    } else {
+      process.env.MULTI_LLM_SESSION_LOCK_TIMEOUT_MS = previousLockTimeout;
+    }
+    if (previousLockRetry === undefined) {
+      delete process.env.MULTI_LLM_SESSION_LOCK_RETRY_DELAY_MS;
+    } else {
+      process.env.MULTI_LLM_SESSION_LOCK_RETRY_DELAY_MS = previousLockRetry;
+    }
+    if (previousLockStale === undefined) {
+      delete process.env.MULTI_LLM_SESSION_LOCK_STALE_MS;
+    } else {
+      process.env.MULTI_LLM_SESSION_LOCK_STALE_MS = previousLockStale;
+    }
+    await fsp.rm(tempHome, { recursive: true, force: true });
+  }
+}
+
+describe("FileSessionStoreAdapter", () => {
+  it("accepts legacy-compatible session ids with dot and colon", async () => {
+    await withTempHome(async () => {
+      const { FileSessionStoreAdapter } =
+        await import("../../../adapters/session/file-session-store.adapter");
+      const adapter = new FileSessionStoreAdapter();
+      const sessionId = "legacy.v1:session-01";
+
+      await adapter.saveSession(sessionId, {
+        model: "model-a",
+        messages: [{ role: "user", content: "hello" }],
+        policy: { maxTurns: 3, summaryEnabled: false },
+        updatedAt: new Date().toISOString(),
+      });
+
+      const loaded = await adapter.getSession(sessionId);
+      expect(loaded?.model).toBe("model-a");
+      expect(loaded?.messages).toEqual([{ role: "user", content: "hello" }]);
+    });
+  });
+
+  it("recovers stale lock left by dead process", async () => {
+    await withTempHome(async (tempHome) => {
+      const { FileSessionStoreAdapter } =
+        await import("../../../adapters/session/file-session-store.adapter");
+      const adapter = new FileSessionStoreAdapter();
+      const configDir = path.join(tempHome, ".multi-llm-agent-cli");
+      const lockPath = path.join(configDir, "session.lock");
+
+      await fsp.mkdir(configDir, { recursive: true });
+      await fsp.writeFile(
+        lockPath,
+        JSON.stringify({ pid: 999999, createdAt: Date.now() - 120_000 }),
+        "utf-8",
+      );
+
+      await adapter.saveSession("s-1", {
+        model: "model-a",
+        messages: [],
+        policy: { maxTurns: 10, summaryEnabled: false },
+        updatedAt: new Date().toISOString(),
+      });
+
+      await expect(fsp.stat(lockPath)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      const loaded = await adapter.getSession("s-1");
+      expect(loaded?.model).toBe("model-a");
+    });
+  });
+
+  it("respects lock timeout and stale thresholds from env", async () => {
+    await withTempHome(async (tempHome) => {
+      process.env.MULTI_LLM_SESSION_LOCK_TIMEOUT_MS = "120";
+      process.env.MULTI_LLM_SESSION_LOCK_RETRY_DELAY_MS = "10";
+      process.env.MULTI_LLM_SESSION_LOCK_STALE_MS = "3600000";
+      jest.resetModules();
+
+      const { FileSessionStoreAdapter } =
+        await import("../../../adapters/session/file-session-store.adapter");
+      const adapter = new FileSessionStoreAdapter();
+      const configDir = path.join(tempHome, ".multi-llm-agent-cli");
+      const lockPath = path.join(configDir, "session.lock");
+
+      await fsp.mkdir(configDir, { recursive: true });
+      await fsp.writeFile(
+        lockPath,
+        JSON.stringify({ pid: 999999, createdAt: Date.now() - 120_000 }),
+        "utf-8",
+      );
+
+      await expect(
+        adapter.saveSession("s-1", {
+          model: "model-a",
+          messages: [],
+          policy: { maxTurns: 10, summaryEnabled: false },
+          updatedAt: new Date().toISOString(),
+        }),
+      ).rejects.toThrow("Timed out waiting for session lock after 120ms");
+    });
+  });
+});

--- a/src/tests/unit/application/main.program.test.ts
+++ b/src/tests/unit/application/main.program.test.ts
@@ -1,5 +1,57 @@
 import { createProgram } from "../../../main";
 import { RunChatUseCase } from "../../../application/chat/run-chat.usecase";
+import * as chatEventLogger from "../../../operations/logging/chat-event-logger";
+
+function createMockUseCase() {
+  return {
+    startSession: jest.fn().mockResolvedValue({
+      ok: true,
+      model: "test-model",
+      source: "default",
+    }),
+    runTurn: jest.fn(async function* () {
+      yield "ok";
+    }),
+    loadContext: jest
+      .fn()
+      .mockResolvedValue({
+        messages: [],
+        policy: { maxTurns: 10, summaryEnabled: false },
+      }),
+    recordTurn: jest.fn().mockResolvedValue(undefined),
+    setContextPolicy: jest.fn().mockResolvedValue({
+      policy: { maxTurns: 5, summaryEnabled: true },
+    }),
+    saveSession: jest
+      .fn()
+      .mockResolvedValue({ savedAt: "2026-01-01T00:00:00.000Z" }),
+    loadSession: jest.fn().mockResolvedValue({
+      restoredMessageCount: 2,
+      restoredSummary: true,
+      session: {
+        model: "test-model",
+        messages: [
+          { role: "user", content: "u1" },
+          { role: "assistant", content: "a1" },
+        ],
+        summary: "sum",
+        policy: { maxTurns: 10, summaryEnabled: false },
+        loadedAt: "2026-01-01T00:00:01.000Z",
+        updatedAt: "2026-01-01T00:00:01.000Z",
+      },
+    }),
+    getSession: jest.fn().mockResolvedValue({
+      model: "test-model",
+      messages: [],
+      policy: { maxTurns: 10, summaryEnabled: false },
+    }),
+    endSession: jest.fn().mockResolvedValue(undefined),
+    clearContext: jest.fn().mockResolvedValue({ messages: [] }),
+    summarizeContext: jest
+      .fn()
+      .mockResolvedValue({ messages: [], summary: "s" }),
+  } as unknown as RunChatUseCase;
+}
 
 describe("createProgram", () => {
   afterEach(() => {
@@ -17,16 +69,7 @@ describe("createProgram", () => {
   });
 
   it("passes sessionId to chat command input", async () => {
-    const useCase = {
-      startSession: jest.fn().mockResolvedValue({
-        ok: true,
-        model: "test-model",
-        source: "default",
-      }),
-      runTurn: jest.fn(async function* () {
-        yield "ok";
-      }),
-    } as unknown as RunChatUseCase;
+    const useCase = createMockUseCase();
 
     const program = createProgram({ useCase });
     jest.spyOn(console, "log").mockImplementation(() => {});
@@ -43,16 +86,7 @@ describe("createProgram", () => {
   });
 
   it("creates a new session id when --session-id is omitted", async () => {
-    const useCase = {
-      startSession: jest.fn().mockResolvedValue({
-        ok: true,
-        model: "test-model",
-        source: "default",
-      }),
-      runTurn: jest.fn(async function* () {
-        yield "ok";
-      }),
-    } as unknown as RunChatUseCase;
+    const useCase = createMockUseCase();
 
     const program = createProgram({ useCase });
     jest.spyOn(console, "log").mockImplementation(() => {});
@@ -64,5 +98,66 @@ describe("createProgram", () => {
       sessionId: expect.stringMatching(/^session-[0-9a-f-]{36}$/),
       cliModel: undefined,
     });
+  });
+
+  it("registers and executes session start command", async () => {
+    const useCase = createMockUseCase();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const program = createProgram({ useCase });
+    await program.parseAsync(
+      ["session", "start", "s-001", "--max-turns", "5", "--summary"],
+      { from: "user" },
+    );
+
+    expect((useCase as any).startSession).toHaveBeenCalledWith({
+      sessionId: "s-001",
+      cliModel: undefined,
+    });
+    expect((useCase as any).setContextPolicy).toHaveBeenCalledWith("s-001", {
+      maxTurns: 5,
+      summaryEnabled: true,
+    });
+    expect(logSpy).toHaveBeenCalledWith("セッションを開始しました: s-001");
+  });
+
+  it("registers and executes session load command with restoration summary", async () => {
+    const useCase = createMockUseCase();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const program = createProgram({ useCase });
+    await program.parseAsync(["session", "load", "s-001"], {
+      from: "user",
+    });
+
+    expect((useCase as any).loadSession).toHaveBeenCalledWith("s-001");
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("セッションを読み込みました: s-001"),
+    );
+    expect(logSpy).toHaveBeenCalledWith("restored_messages=2");
+    expect(logSpy).toHaveBeenCalledWith("restored_summary=yes");
+  });
+
+  it("writes session operation events when --log-events is enabled", async () => {
+    const useCase = createMockUseCase();
+    const writeLogSpy = jest
+      .spyOn(chatEventLogger, "writeChatEventLog")
+      .mockResolvedValue(undefined);
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const program = createProgram({ useCase });
+    await program.parseAsync(["session", "save", "s-001", "--log-events"], {
+      from: "user",
+    });
+
+    expect(writeLogSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: "s-001",
+        event_type: "session_save",
+      }),
+    );
   });
 });

--- a/src/tests/unit/interaction/chat.command.test.ts
+++ b/src/tests/unit/interaction/chat.command.test.ts
@@ -59,12 +59,23 @@ describe("chat.command interaction serialization", () => {
       yield "second-response";
     });
 
+    const storedMessages: Message[] = [];
     const useCase = {
       startSession: jest.fn().mockResolvedValue({
         ok: true,
         model: "test-model",
         source: "default",
       }),
+      loadContext: jest.fn(async () => ({
+        messages: [...storedMessages],
+        policy: { maxTurns: 10, summaryEnabled: false },
+      })),
+      recordTurn: jest.fn(
+        async (_sid: string, user: string, assistant: string) => {
+          storedMessages.push({ role: "user", content: user });
+          storedMessages.push({ role: "assistant", content: assistant });
+        },
+      ),
       runTurn,
     } as unknown as RunChatUseCase;
 
@@ -112,6 +123,13 @@ describe("chat.command interaction serialization", () => {
         model: "test-model",
         source: "default",
       }),
+      loadContext: jest
+        .fn()
+        .mockResolvedValue({
+          messages: [],
+          policy: { maxTurns: 10, summaryEnabled: false },
+        }),
+      recordTurn: jest.fn().mockResolvedValue(undefined),
       runTurn: jest.fn(async function* () {
         yield "chunk-1";
         yield "chunk-2";

--- a/src/tests/unit/operations/chat-event-logger.test.ts
+++ b/src/tests/unit/operations/chat-event-logger.test.ts
@@ -96,4 +96,19 @@ describe("chat-event-logger", () => {
     expect(chmodSpy).toHaveBeenCalledWith(customLogFile, 0o600);
     chmodSpy.mockRestore();
   });
+
+  it("writes session/context events without model metadata", async () => {
+    const logFile = path.join(tempDir, "chat-events.jsonl");
+    process.env.CHAT_EVENT_LOG_FILE = logFile;
+
+    await writeChatEventLog({
+      timestamp: "2026-02-15T00:00:00.000Z",
+      session_id: "s-1",
+      event_type: "context_clear",
+    });
+
+    const current = await fsp.readFile(logFile, "utf-8");
+    expect(current).toContain('"event_type":"context_clear"');
+    expect(current).toContain('"session_id":"s-1"');
+  });
 });


### PR DESCRIPTION
## 概要 (Summary)
Issue #38 (S1.3 セッション・コンテキスト) に対応し、session/context 操作と永続化・ログ・テストを追加しました。

## 関連Issue (Related Issues)
Closes #38

## 変更の種類 (Type of Change)
- [x] 新機能 (New feature)
- [x] バグ修正 (Bug fix)
- [ ] リファクタリング (Refactoring)
- [x] ドキュメント更新 (Documentation)

## 詳細な変更点 (Detailed Changes)
- `src/main.ts`: `session start/save/load/end` と `session context show/set/clear/summarize` をCLIとして実装。`--log-events` オプションを追加。
- `src/application/chat/run-chat.usecase.ts`: セッション開始/保存/読込/終了、コンテキスト保持/破棄/要約、履歴記録を実装。`loadSession` で復元結果を返却。
- `src/adapters/session/file-session-store.adapter.ts`: `session.json` 永続化、atomic write、lock取得/回復、lock設定値の環境変数対応を追加。
- `src/operations/logging/chat-event-logger.ts`: session/context 操作用イベント種別を追加。
- `src/ports/outbound/session-store.port.ts`: `SessionRecord` に `loadedAt` を追加しセッション情報を拡張。
- `src/tests/...`: F-004/F-005 受け入れテストと、usecase/main/logger/adapter のユニットテストを追加・更新。
- `README.md`, `doc/CURRENT_PLAN.md`: セッション機能・実装計画を更新。

## 動作確認手順 (Verification Steps)
1. `npm run lint` が成功すること
2. `npm test` が成功すること
3. `multi-llm-agent-cli session start s-1 --max-turns 5 --summary` -> `session save s-1` -> `session load s-1` で復元情報が表示されること
4. `multi-llm-agent-cli session context summarize s-1` / `clear s-1 --keep-turns 0` が反映されること

## 自己チェック (Self Check)
- [x] 既存のテストを壊していないか
- [x] 機密情報（API Key等）が含まれていないか
