### PR TITLE
feat(orchestration): implement S2.1 role execution model (F-101/F-102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ multi-llm-agent-cli use <model_name>
   - `clear --keep-turns N`: 履歴を破棄（最新Nターンのみ保持、既存summaryも破棄）
   - `summarize`: 古い履歴を要約して圧縮
 
+### ロール実行モデル (MVP, F-101/F-102)
+
+- `MCP orchestrate/task` 実行時に、論理ロール `coordinator/developer/reviewer/documenter` を単一 Control Node 内で順次実行します。
+- 委譲表示:
+  - `task_status_update` 通知で `delegatedRole`, `parentTaskId`, `childTaskId` を確認できます。
+- 監査ログ:
+  - `event_type=role_delegation` として `parent_task_id`, `child_task_id`, `delegated_role`, `delegated_at`, `result_at`, `failure_reason` を保存します。
+- 制約 (MVP):
+  - リモートAgent常駐やノード間通信は未対応です。
+  - 並列ロール実行（F-103）は未対応です。
+
 ## 開発フック
 
 コミット前とプッシュ前に品質チェックを強制するため、Git hookを利用します。

--- a/src/application/orchestration/dispatch-task.usecase.ts
+++ b/src/application/orchestration/dispatch-task.usecase.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "crypto";
+import {
+  canDelegateRole,
+  RoleName,
+} from "../../domain/orchestration/entities/role";
+import { RoleTask } from "../../domain/orchestration/entities/task";
+
+export class DispatchTaskUseCase {
+  private readonly tasks = new Map<string, RoleTask>();
+
+  constructor(
+    private readonly now: () => string = () => new Date().toISOString(),
+    private readonly createTaskId: () => string = () => `task-${randomUUID()}`,
+  ) {}
+
+  createRootTask(role: RoleName, prompt: string): RoleTask {
+    const task: RoleTask = {
+      taskId: this.createTaskId(),
+      role,
+      prompt,
+      status: "queued",
+      delegatedAt: this.now(),
+    };
+    this.tasks.set(task.taskId, task);
+    return task;
+  }
+
+  delegateTask(parentTaskId: string, role: RoleName, prompt: string): RoleTask {
+    const parentTask = this.tasks.get(parentTaskId);
+    if (!parentTask) {
+      throw new Error(`Parent task not found: ${parentTaskId}`);
+    }
+    if (!canDelegateRole(parentTask.role, role)) {
+      throw new Error(
+        `Role delegation is not allowed: ${parentTask.role} -> ${role}`,
+      );
+    }
+
+    const task: RoleTask = {
+      taskId: this.createTaskId(),
+      parentTaskId,
+      role,
+      prompt,
+      status: "queued",
+      delegatedAt: this.now(),
+    };
+    this.tasks.set(task.taskId, task);
+    return task;
+  }
+
+  markTaskRunning(taskId: string): RoleTask {
+    const task = this.tasks.get(taskId);
+    if (!task) {
+      throw new Error(`Task not found: ${taskId}`);
+    }
+    task.status = "running";
+    return task;
+  }
+
+  completeTask(taskId: string, output: string): RoleTask {
+    const task = this.tasks.get(taskId);
+    if (!task) {
+      throw new Error(`Task not found: ${taskId}`);
+    }
+    task.status = "completed";
+    task.output = output;
+    task.resultAt = this.now();
+    return task;
+  }
+
+  failTask(taskId: string, reason: string): RoleTask {
+    const task = this.tasks.get(taskId);
+    if (!task) {
+      throw new Error(`Task not found: ${taskId}`);
+    }
+    task.status = "failed";
+    task.failureReason = reason;
+    task.resultAt = this.now();
+    return task;
+  }
+
+  getTask(taskId: string): RoleTask | undefined {
+    return this.tasks.get(taskId);
+  }
+
+  listChildren(parentTaskId: string): RoleTask[] {
+    return Array.from(this.tasks.values()).filter(
+      (task) => task.parentTaskId === parentTaskId,
+    );
+  }
+}

--- a/src/application/orchestration/run-role-graph.usecase.ts
+++ b/src/application/orchestration/run-role-graph.usecase.ts
@@ -77,7 +77,11 @@ export class RunRoleGraphUseCase {
         finalResponse,
       );
       await this.pushEvent(events, this.buildEvent(documenterCompleted));
-      this.dispatchTask.completeTask(rootTask.taskId, finalResponse);
+      const rootCompleted = this.dispatchTask.completeTask(
+        rootTask.taskId,
+        finalResponse,
+      );
+      await this.pushEvent(events, this.buildEvent(rootCompleted));
 
       return {
         rootTaskId: rootTask.taskId,

--- a/src/application/orchestration/run-role-graph.usecase.ts
+++ b/src/application/orchestration/run-role-graph.usecase.ts
@@ -1,0 +1,135 @@
+import { DispatchTaskUseCase } from "./dispatch-task.usecase";
+import { RoleDelegationEvent } from "../../shared/types/events";
+import { RoleTask } from "../../domain/orchestration/entities/task";
+import { RoleName } from "../../domain/orchestration/entities/role";
+
+export interface RunRoleGraphResult {
+  rootTaskId: string;
+  finalResponse: string;
+  events: RoleDelegationEvent[];
+  tasks: RoleTask[];
+}
+
+export class RunRoleGraphUseCase {
+  constructor(
+    private readonly dispatchTask: DispatchTaskUseCase,
+    private readonly runRole: (
+      role: RoleName,
+      prompt: string,
+    ) => Promise<string>,
+    private readonly onEvent?: (
+      event: RoleDelegationEvent,
+    ) => void | Promise<void>,
+  ) {}
+
+  async execute(userPrompt: string): Promise<RunRoleGraphResult> {
+    const rootTask = this.dispatchTask.createRootTask(
+      "coordinator",
+      userPrompt,
+    );
+    this.dispatchTask.markTaskRunning(rootTask.taskId);
+    const events: RoleDelegationEvent[] = [];
+    const allTasks: RoleTask[] = [rootTask];
+
+    try {
+      const coordinatorOutput = await this.runRole("coordinator", userPrompt);
+      const developerTask = this.dispatchTask.delegateTask(
+        rootTask.taskId,
+        "developer",
+        coordinatorOutput,
+      );
+      allTasks.push(developerTask);
+      this.dispatchTask.markTaskRunning(developerTask.taskId);
+      const developerOutput = await this.runRole(
+        "developer",
+        coordinatorOutput,
+      );
+      const developerCompleted = this.dispatchTask.completeTask(
+        developerTask.taskId,
+        developerOutput,
+      );
+      await this.pushEvent(events, this.buildEvent(developerCompleted));
+
+      const reviewerTask = this.dispatchTask.delegateTask(
+        rootTask.taskId,
+        "reviewer",
+        developerOutput,
+      );
+      allTasks.push(reviewerTask);
+      this.dispatchTask.markTaskRunning(reviewerTask.taskId);
+      const reviewerOutput = await this.runRole("reviewer", developerOutput);
+      const reviewerCompleted = this.dispatchTask.completeTask(
+        reviewerTask.taskId,
+        reviewerOutput,
+      );
+      await this.pushEvent(events, this.buildEvent(reviewerCompleted));
+
+      const documenterTask = this.dispatchTask.delegateTask(
+        rootTask.taskId,
+        "documenter",
+        reviewerOutput,
+      );
+      allTasks.push(documenterTask);
+      this.dispatchTask.markTaskRunning(documenterTask.taskId);
+      const finalResponse = await this.runRole("documenter", reviewerOutput);
+      const documenterCompleted = this.dispatchTask.completeTask(
+        documenterTask.taskId,
+        finalResponse,
+      );
+      await this.pushEvent(events, this.buildEvent(documenterCompleted));
+      this.dispatchTask.completeTask(rootTask.taskId, finalResponse);
+
+      return {
+        rootTaskId: rootTask.taskId,
+        finalResponse,
+        events,
+        tasks: allTasks,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const runningChild = allTasks
+        .filter((task) => task.parentTaskId === rootTask.taskId)
+        .find((task) => task.status === "running");
+      if (runningChild) {
+        const failedTask = this.dispatchTask.failTask(
+          runningChild.taskId,
+          message,
+        );
+        await this.pushEvent(events, this.buildEvent(failedTask));
+      }
+      const failedRoot = this.dispatchTask.failTask(rootTask.taskId, message);
+      if (!runningChild) {
+        await this.pushEvent(events, this.buildEvent(failedRoot));
+      }
+      throw error;
+    }
+  }
+
+  private async pushEvent(
+    events: RoleDelegationEvent[],
+    event: RoleDelegationEvent,
+  ): Promise<void> {
+    events.push(event);
+    if (this.onEvent) {
+      try {
+        await this.onEvent(event);
+      } catch (error) {
+        // Keep event callback failures visible without breaking orchestration.
+        console.error("Role delegation event propagation failed:", error);
+      }
+    }
+  }
+
+  private buildEvent(task: RoleTask): RoleDelegationEvent {
+    return {
+      event_type: "role_delegation",
+      status: task.status,
+      task_id: task.taskId,
+      parent_task_id: task.parentTaskId,
+      delegated_role: task.role,
+      delegated_at: task.delegatedAt,
+      result_at: task.resultAt,
+      failure_reason: task.failureReason,
+    };
+  }
+}

--- a/src/domain/orchestration/entities/role.ts
+++ b/src/domain/orchestration/entities/role.ts
@@ -1,0 +1,54 @@
+export type RoleName = "coordinator" | "developer" | "reviewer" | "documenter";
+
+export interface RoleDefinition {
+  name: RoleName;
+  responsibility: string;
+  delegatableTo: RoleName[];
+}
+
+const ROLE_CATALOG: ReadonlyArray<RoleDefinition> = [
+  {
+    name: "coordinator",
+    responsibility: "ユーザー要求を解釈し、実行計画と委譲順序を決める。",
+    delegatableTo: ["developer", "reviewer", "documenter"],
+  },
+  {
+    name: "developer",
+    responsibility: "実装タスクを処理し、成果物を生成する。",
+    delegatableTo: ["reviewer", "documenter"],
+  },
+  {
+    name: "reviewer",
+    responsibility: "成果物を検証し、不備やリスクを指摘する。",
+    delegatableTo: ["documenter"],
+  },
+  {
+    name: "documenter",
+    responsibility: "最終成果をユーザー向けに整理して出力する。",
+    delegatableTo: [],
+  },
+];
+
+export function listRoleDefinitions(): RoleDefinition[] {
+  return ROLE_CATALOG.map((role) => ({
+    ...role,
+    delegatableTo: [...role.delegatableTo],
+  }));
+}
+
+export function getRoleDefinition(roleName: RoleName): RoleDefinition {
+  const role = ROLE_CATALOG.find((item) => item.name === roleName);
+  if (!role) {
+    throw new Error(`Unknown role: ${roleName}`);
+  }
+  return { ...role, delegatableTo: [...role.delegatableTo] };
+}
+
+export function canDelegateRole(fromRole: RoleName, toRole: RoleName): boolean {
+  const from = getRoleDefinition(fromRole);
+  return from.delegatableTo.includes(toRole);
+}
+
+export function isRoleName(value: string): value is RoleName {
+  return ROLE_CATALOG.some((role) => role.name === value);
+}

--- a/src/domain/orchestration/entities/task.ts
+++ b/src/domain/orchestration/entities/task.ts
@@ -1,0 +1,15 @@
+import { RoleName } from "./role";
+
+export type RoleTaskStatus = "queued" | "running" | "completed" | "failed";
+
+export interface RoleTask {
+  taskId: string;
+  parentTaskId?: string;
+  role: RoleName;
+  prompt: string;
+  status: RoleTaskStatus;
+  delegatedAt: string;
+  resultAt?: string;
+  failureReason?: string;
+  output?: string;
+}

--- a/src/mcp/McpServer.ts
+++ b/src/mcp/McpServer.ts
@@ -30,7 +30,7 @@ function tokenizeArithmeticExpression(expression: string): ArithmeticToken[] {
         end += 1;
       }
       const raw = expression.slice(index, end);
-      if (!/^\d+(\.\d+)?$/.test(raw)) {
+      if (!/^(?:\d+(?:\.\d*)?|\.\d+)$/.test(raw)) {
         throw new Error(`Invalid numeric literal: ${raw}`);
       }
       tokens.push({ kind: "number", value: Number(raw) });
@@ -319,18 +319,20 @@ export class McpServer {
               this.tasks.get(taskId)!.status = "completed";
             })
             .catch((error) => {
+              const errorMessage =
+                error instanceof Error ? error.message : String(error);
               logger.error(`Orchestration failed for task ${taskId}:`, error);
               this.sendError(
                 ws,
                 request.id,
                 -32000,
-                `Orchestration failed: ${error.message}`,
+                `Orchestration failed: ${errorMessage}`,
               );
               this.tasks.get(taskId)!.status = "failed";
               this.sendNotification(ws, "task_status_update", {
                 taskId,
                 status: "failed",
-                message: `Orchestration failed: ${error.message}`,
+                message: `Orchestration failed: ${errorMessage}`,
               });
             });
           break;

--- a/src/mcp/McpServer.ts
+++ b/src/mcp/McpServer.ts
@@ -1,19 +1,169 @@
-import { WebSocketServer, WebSocket } from 'ws';
-import { OllamaClient, Message } from '../ollama/OllamaClient';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
-import { logger } from '../utils/logger';
+import { WebSocketServer, WebSocket } from "ws";
+import { OllamaClient, Message } from "../ollama/OllamaClient";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { logger } from "../utils/logger";
+import { DispatchTaskUseCase } from "../application/orchestration/dispatch-task.usecase";
+import { RunRoleGraphUseCase } from "../application/orchestration/run-role-graph.usecase";
+import { RoleName } from "../domain/orchestration/entities/role";
+import { RoleDelegationEvent } from "../shared/types/events";
+import { writeChatEventLog } from "../operations/logging/chat-event-logger";
+
+type ArithmeticToken =
+  | { kind: "number"; value: number }
+  | { kind: "op"; value: "+" | "-" | "*" | "/" }
+  | { kind: "paren"; value: "(" | ")" };
+
+function tokenizeArithmeticExpression(expression: string): ArithmeticToken[] {
+  const tokens: ArithmeticToken[] = [];
+  let index = 0;
+  while (index < expression.length) {
+    const ch = expression[index];
+    if (/\s/.test(ch)) {
+      index += 1;
+      continue;
+    }
+    if (/[0-9.]/.test(ch)) {
+      let end = index + 1;
+      while (end < expression.length && /[0-9.]/.test(expression[end])) {
+        end += 1;
+      }
+      const raw = expression.slice(index, end);
+      if (!/^\d+(\.\d+)?$/.test(raw)) {
+        throw new Error(`Invalid numeric literal: ${raw}`);
+      }
+      tokens.push({ kind: "number", value: Number(raw) });
+      index = end;
+      continue;
+    }
+    if (ch === "+" || ch === "-" || ch === "*" || ch === "/") {
+      tokens.push({ kind: "op", value: ch });
+      index += 1;
+      continue;
+    }
+    if (ch === "(" || ch === ")") {
+      tokens.push({ kind: "paren", value: ch });
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unsupported character: ${ch}`);
+  }
+  return tokens;
+}
+
+function precedence(op: "+" | "-" | "*" | "/"): number {
+  if (op === "+" || op === "-") {
+    return 1;
+  }
+  return 2;
+}
+
+function applyOperator(values: number[], op: "+" | "-" | "*" | "/"): void {
+  if (values.length < 2) {
+    throw new Error("Invalid expression");
+  }
+  const right = values.pop()!;
+  const left = values.pop()!;
+  if (op === "+") {
+    values.push(left + right);
+    return;
+  }
+  if (op === "-") {
+    values.push(left - right);
+    return;
+  }
+  if (op === "*") {
+    values.push(left * right);
+    return;
+  }
+  if (right === 0) {
+    throw new Error("Division by zero");
+  }
+  values.push(left / right);
+}
+
+export function evaluateArithmeticExpression(expression: string): number {
+  const tokens = tokenizeArithmeticExpression(expression);
+  if (tokens.length === 0) {
+    throw new Error("Expression is empty");
+  }
+  const values: number[] = [];
+  const operators: Array<"+" | "-" | "*" | "/" | "("> = [];
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.kind === "number") {
+      values.push(token.value);
+      continue;
+    }
+    if (token.kind === "paren" && token.value === "(") {
+      operators.push("(");
+      continue;
+    }
+    if (token.kind === "paren" && token.value === ")") {
+      while (operators.length > 0 && operators[operators.length - 1] !== "(") {
+        applyOperator(values, operators.pop() as "+" | "-" | "*" | "/");
+      }
+      if (operators.pop() !== "(") {
+        throw new Error("Mismatched parentheses");
+      }
+      continue;
+    }
+    if (token.kind === "op") {
+      const prev = tokens[i - 1];
+      const next = tokens[i + 1];
+      const isUnaryMinusContext =
+        token.value === "-" &&
+        (!prev ||
+          (prev.kind !== "number" &&
+            !(prev.kind === "paren" && prev.value === ")")));
+      if (isUnaryMinusContext && next?.kind === "number") {
+        values.push(-next.value);
+        i += 1;
+        continue;
+      }
+      if (isUnaryMinusContext && next?.kind === "paren" && next.value === "(") {
+        // Support expressions like "-(1+2)" as "0-(1+2)".
+        values.push(0);
+      }
+
+      while (operators.length > 0) {
+        const top = operators[operators.length - 1];
+        if (top === "(") {
+          break;
+        }
+        if (precedence(top) < precedence(token.value)) {
+          break;
+        }
+        applyOperator(values, operators.pop() as "+" | "-" | "*" | "/");
+      }
+      operators.push(token.value);
+    }
+  }
+
+  while (operators.length > 0) {
+    const op = operators.pop()!;
+    if (op === "(") {
+      throw new Error("Mismatched parentheses");
+    }
+    applyOperator(values, op);
+  }
+  if (values.length !== 1 || !Number.isFinite(values[0])) {
+    throw new Error("Invalid expression");
+  }
+  return values[0];
+}
 
 interface JsonRpcRequest {
-  jsonrpc: '2.0';
+  jsonrpc: "2.0";
   id: string | number;
   method: string;
   params?: any;
 }
 
 interface JsonRpcResponse {
-  jsonrpc: '2.0';
+  jsonrpc: "2.0";
   id: string | number | null;
   result?: any;
   error?: {
@@ -26,16 +176,16 @@ interface JsonRpcResponse {
 interface Task {
   id: string;
   prompt: string;
-  status: 'pending' | 'orchestrating' | 'working' | 'completed' | 'failed';
-  orchestratorOutput?: string;
-  workerOutput?: string;
+  status: "pending" | "orchestrating" | "working" | "completed" | "failed";
+  roleComposition?: RoleName[];
+  delegationEvents?: RoleDelegationEvent[];
   finalResponse?: string;
 }
 
 // ツール関数の型定義
 type ToolFunction = (...args: any[]) => Promise<any>;
 
-const PLUGIN_DIR = path.join(os.homedir(), '.multi-llm-agent-cli', 'plugins');
+const PLUGIN_DIR = path.join(os.homedir(), ".multi-llm-agent-cli", "plugins");
 
 export class McpServer {
   private wss: WebSocketServer;
@@ -47,13 +197,12 @@ export class McpServer {
   constructor(port: number = 8080) {
     this.wss = new WebSocketServer({ port });
     this.orchestratorLLM = new OllamaClient(); // 指示者LLM
-    this.workerLLM = new OllamaClient();     // 作業者LLM
+    this.workerLLM = new OllamaClient(); // 作業者LLM
 
     // ダミーのツールを登録
-    this.registerTool('calculator', async (expression: string) => {
+    this.registerTool("calculator", async (expression: string) => {
       try {
-        // 簡易的な計算処理
-        const result = eval(expression); // evalの使用はセキュリティリスクがあるため、実際のプロダクションでは避けるべき
+        const result = evaluateArithmeticExpression(expression);
         return `計算結果: ${expression} = ${result}`;
       } catch (e: any) {
         return `計算エラー: ${e instanceof Error ? e.message : String(e)}`;
@@ -64,24 +213,24 @@ export class McpServer {
 
     logger.info(`MCP Server started on ws://localhost:${port}`);
 
-    this.wss.on('connection', ws => {
-      logger.info('Client connected');
+    this.wss.on("connection", (ws) => {
+      logger.info("Client connected");
 
-      ws.on('message', message => {
+      ws.on("message", (message) => {
         this.handleMessage(ws, message.toString());
       });
 
-      ws.on('close', () => {
-        logger.info('Client disconnected');
+      ws.on("close", () => {
+        logger.info("Client disconnected");
       });
 
-      ws.on('error', error => {
-        logger.error('WebSocket error:', error);
+      ws.on("error", (error) => {
+        logger.error("WebSocket error:", error);
       });
     });
 
-    this.wss.on('error', error => {
-      logger.error('WebSocket server error:', error);
+    this.wss.on("error", (error) => {
+      logger.error("WebSocket server error:", error);
     });
   }
 
@@ -105,17 +254,21 @@ export class McpServer {
       return;
     }
 
-    const pluginFiles = fs.readdirSync(PLUGIN_DIR).filter(file => file.endsWith('.js'));
+    const pluginFiles = fs
+      .readdirSync(PLUGIN_DIR)
+      .filter((file) => file.endsWith(".js"));
 
     for (const file of pluginFiles) {
       const pluginPath = path.join(PLUGIN_DIR, file);
       try {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const plugin = require(pluginPath);
-        if (plugin.name && typeof plugin.handler === 'function') {
+        if (plugin.name && typeof plugin.handler === "function") {
           this.registerTool(plugin.name, plugin.handler);
         } else {
-          logger.warn(`Invalid plugin format: ${file}. Must export 'name' and 'handler' function.`);
+          logger.warn(
+            `Invalid plugin format: ${file}. Must export 'name' and 'handler' function.`,
+          );
         }
       } catch (e: any) {
         if (e instanceof Error) {
@@ -131,129 +284,243 @@ export class McpServer {
     try {
       const request: JsonRpcRequest = JSON.parse(message);
 
-      if (request.jsonrpc !== '2.0' || !request.method) {
-        this.sendError(ws, request.id || null, -32600, 'Invalid Request');
+      if (request.jsonrpc !== "2.0" || !request.method) {
+        this.sendError(ws, request.id || null, -32600, "Invalid Request");
         return;
       }
 
       let result: any;
       switch (request.method) {
-        case 'initialize':
+        case "initialize":
           result = { capabilities: {} }; // Basic capabilities for now
           this.sendResponse(ws, request.id, result);
           // Send initialized notification
-          this.sendNotification(ws, 'initialized', {});
+          this.sendNotification(ws, "initialized", {});
           break;
-        case 'roots/list':
+        case "roots/list":
           result = { roots: [] }; // No roots for now
           this.sendResponse(ws, request.id, result);
           break;
-        case 'orchestrate/task': // 新しいメソッド: オーケストレーションタスクの開始
+        case "orchestrate/task": // 新しいメソッド: オーケストレーションタスクの開始
           const userPrompt = request.params.prompt;
           const taskId = `task-${Date.now()}`;
-          this.tasks.set(taskId, { id: taskId, prompt: userPrompt, status: 'pending' });
+          this.tasks.set(taskId, {
+            id: taskId,
+            prompt: userPrompt,
+            status: "pending",
+          });
 
           this.runOrchestration(taskId, userPrompt, ws) // WebSocketを渡して進捗を通知できるようにする
-            .then(finalResponse => {
-              this.sendResponse(ws, request.id, { response: finalResponse, taskId: taskId });
-              this.tasks.get(taskId)!.status = 'completed';
+            .then((finalResponse) => {
+              this.sendResponse(ws, request.id, {
+                response: finalResponse,
+                taskId: taskId,
+              });
+              this.tasks.get(taskId)!.status = "completed";
             })
-            .catch(error => {
+            .catch((error) => {
               logger.error(`Orchestration failed for task ${taskId}:`, error);
-              this.sendError(ws, request.id, -32000, `Orchestration failed: ${error.message}`);
-              this.tasks.get(taskId)!.status = 'failed';
+              this.sendError(
+                ws,
+                request.id,
+                -32000,
+                `Orchestration failed: ${error.message}`,
+              );
+              this.tasks.get(taskId)!.status = "failed";
+              this.sendNotification(ws, "task_status_update", {
+                taskId,
+                status: "failed",
+                message: `Orchestration failed: ${error.message}`,
+              });
             });
           break;
         default:
-          this.sendError(ws, request.id, -32601, `Method not found: ${request.method}`);
+          this.sendError(
+            ws,
+            request.id,
+            -32601,
+            `Method not found: ${request.method}`,
+          );
           break;
       }
     } catch (error) {
-      logger.error('Error parsing message or handling request:', error);
-      this.sendError(ws, null, -32700, 'Parse error');
+      logger.error("Error parsing message or handling request:", error);
+      this.sendError(ws, null, -32700, "Parse error");
     }
   }
 
-  private async runOrchestration(taskId: string, userPrompt: string, ws: WebSocket): Promise<string> {
+  private async runOrchestration(
+    taskId: string,
+    userPrompt: string,
+    ws: WebSocket,
+  ): Promise<string> {
     const task = this.tasks.get(taskId)!;
-    task.status = 'orchestrating';
-    this.sendNotification(ws, 'task_status_update', { taskId, status: task.status, message: 'Orchestrator LLM processing...' });
+    task.status = "orchestrating";
+    this.sendNotification(ws, "task_status_update", {
+      taskId,
+      status: task.status,
+      message:
+        "Role graph orchestration started (coordinator/developer/reviewer/documenter).",
+    });
 
-    // Step 1: Orchestrator LLM processes the user prompt
-    const orchestratorMessages: Message[] = [
-      { role: 'user', content: `ユーザーの要求をタスクに分解し、必要に応じてツールを呼び出し、作業者LLMに指示してください。利用可能なツール: ${Array.from(this.tools.keys()).join(', ')}` },
-      { role: 'user', content: userPrompt }
+    const dispatchTask = new DispatchTaskUseCase();
+    const roleGraph = new RunRoleGraphUseCase(
+      dispatchTask,
+      (role, prompt) => this.executeRole(role, prompt, taskId, ws),
+      async (event) => {
+        this.sendRoleDelegationNotification(ws, taskId, event);
+        try {
+          await this.writeRoleDelegationLog(taskId, event);
+        } catch (error: any) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          logger.error(
+            `Role delegation audit log write failed for task ${taskId}:`,
+            message,
+          );
+          this.sendNotification(ws, "task_status_update", {
+            taskId,
+            status: event.status,
+            message: `Audit log write failed: ${message}`,
+            auditLogError: true,
+          });
+        }
+      },
+    );
+
+    const result = await roleGraph.execute(userPrompt);
+    task.status = "completed";
+    task.roleComposition = result.tasks.map((roleTask) => roleTask.role);
+    task.delegationEvents = result.events;
+    task.finalResponse = result.finalResponse;
+    this.sendNotification(ws, "task_status_update", {
+      taskId,
+      status: task.status,
+      message: `Role execution completed: ${task.roleComposition.join(" -> ")}`,
+    });
+
+    return result.finalResponse;
+  }
+
+  private async executeRole(
+    role: RoleName,
+    prompt: string,
+    taskId: string,
+    ws: WebSocket,
+  ): Promise<string> {
+    const client =
+      role === "documenter" ? this.orchestratorLLM : this.workerLLM;
+    const messages: Message[] = [
+      {
+        role: "system",
+        content: this.getRolePrompt(role),
+      },
+      {
+        role: "user",
+        content: prompt,
+      },
     ];
-    let orchestratorOutput = '';
-    for await (const chunk of this.orchestratorLLM.chat('llama2', orchestratorMessages)) { // モデル名は仮
+    let output = "";
+    for await (const chunk of client.chat("llama2", messages)) {
       if (chunk.message?.content) {
-        orchestratorOutput += chunk.message.content;
-      }
-    }
-    task.orchestratorOutput = orchestratorOutput;
-    this.sendNotification(ws, 'task_status_update', { taskId, status: task.status, message: 'Orchestrator LLM finished. Checking for tool calls...' });
-
-    // ツール呼び出しのシミュレーション
-    const toolCallMatch = orchestratorOutput.match(/CALL_TOOL\(([^,]+),\s*(.*)\)/);
-    let toolResult = '';
-    if (toolCallMatch) {
-      const toolName = toolCallMatch[1].trim();
-      const toolArgs = toolCallMatch[2].trim();
-      this.sendNotification(ws, 'task_status_update', { taskId, status: task.status, message: `Calling tool: ${toolName} with args: ${toolArgs}` });
-      try {
-        toolResult = await this.callTool(toolName, toolArgs);
-        this.sendNotification(ws, 'task_status_update', { taskId, status: task.status, message: `Tool result: ${toolResult}` });
-      } catch (e: any) {
-        toolResult = `Tool error: ${e instanceof Error ? e.message : String(e)}`;
-        this.sendNotification(ws, 'task_status_update', { taskId, status: task.status, message: toolResult });
+        output += chunk.message.content;
       }
     }
 
-    // Step 2: Simulate task assignment to Worker LLM
-    task.status = 'working';
-    this.sendNotification(ws, 'task_status_update', { taskId, status: task.status, message: 'Worker LLM processing...' });
-    const workerMessages: Message[] = [
-      { role: 'user', content: `指示者からのタスク: ${orchestratorOutput}` },
-      { role: 'assistant', content: `ツール実行結果: ${toolResult}` }
-    ];
-    let workerOutput = '';
-    for await (const chunk of this.workerLLM.chat('llama2', workerMessages)) { // モデル名は仮
-      if (chunk.message?.content) {
-        workerOutput += chunk.message.content;
-      }
+    const toolCallMatch = output.match(/CALL_TOOL\(([^,]+),\s*(.*)\)/);
+    if (!toolCallMatch) {
+      return output;
     }
-    task.workerOutput = workerOutput;
-    this.sendNotification(ws, 'task_status_update', { taskId, status: task.status, message: 'Worker LLM finished. Synthesizing final response...' });
+    const toolName = toolCallMatch[1].trim();
+    const toolArgs = toolCallMatch[2].trim();
+    this.sendNotification(ws, "task_status_update", {
+      taskId,
+      status: "working",
+      message: `Role ${role} requested tool: ${toolName}(${toolArgs})`,
+    });
+    try {
+      const toolResult = await this.callTool(toolName, toolArgs);
+      return `${output}\n\nTool result: ${toolResult}`;
+    } catch (e: any) {
+      const toolError = e instanceof Error ? e.message : String(e);
+      return `${output}\n\nTool error: ${toolError}`;
+    }
+  }
 
-    // Step 3: Orchestrator LLM synthesizes the final response
-    const finalMessages: Message[] = [
-      { role: 'user', content: `ユーザーの要求: ${userPrompt}` },
-      { role: 'assistant', content: `作業者LLMの実行結果: ${workerOutput}` },
-      { role: 'assistant', content: `ツール実行結果: ${toolResult}` },
-      { role: 'user', content: 'この結果に基づいて、ユーザーへの最終的な応答を生成してください。' }
-    ];
-    let finalResponse = '';
-    for await (const chunk of this.orchestratorLLM.chat('llama2', finalMessages)) { // モデル名は仮
-      if (chunk.message?.content) {
-        finalResponse += chunk.message.content;
-      }
+  private getRolePrompt(role: RoleName): string {
+    if (role === "developer") {
+      return "You are developer role. Produce implementation-focused output in concise Japanese.";
     }
-    task.finalResponse = finalResponse;
-    return finalResponse;
+    if (role === "reviewer") {
+      return "You are reviewer role. Validate risks and correctness in concise Japanese.";
+    }
+    if (role === "documenter") {
+      return "You are documenter role. Produce final user-facing answer in concise Japanese.";
+    }
+    return "You are coordinator role.";
+  }
+
+  private sendRoleDelegationNotification(
+    ws: WebSocket,
+    taskId: string,
+    event: RoleDelegationEvent,
+  ) {
+    const message =
+      event.status === "failed"
+        ? `Delegated to ${event.delegated_role} failed: ${event.failure_reason ?? "unknown error"}`
+        : `Delegated to ${event.delegated_role} completed`;
+    this.sendNotification(ws, "task_status_update", {
+      taskId,
+      parentTaskId: event.parent_task_id,
+      childTaskId: event.task_id,
+      status: event.status,
+      delegatedRole: event.delegated_role,
+      delegatedAt: event.delegated_at,
+      resultAt: event.result_at,
+      failureReason: event.failure_reason,
+      message,
+    });
+  }
+
+  private async writeRoleDelegationLog(
+    taskId: string,
+    event: RoleDelegationEvent,
+  ): Promise<void> {
+    await writeChatEventLog({
+      timestamp: new Date().toISOString(),
+      session_id: taskId,
+      event_type: "role_delegation",
+      parent_task_id: event.parent_task_id,
+      child_task_id: event.task_id,
+      delegated_role: event.delegated_role,
+      delegated_at: event.delegated_at,
+      result_at: event.result_at,
+      failure_reason: event.failure_reason,
+    });
   }
 
   private sendResponse(ws: WebSocket, id: string | number, result: any) {
-    const response: JsonRpcResponse = { jsonrpc: '2.0', id, result };
+    const response: JsonRpcResponse = { jsonrpc: "2.0", id, result };
     ws.send(JSON.stringify(response));
   }
 
-  private sendError(ws: WebSocket, id: string | number | null, code: number, message: string, data?: any) {
-    const response: JsonRpcResponse = { jsonrpc: '2.0', id, error: { code, message, data } };
+  private sendError(
+    ws: WebSocket,
+    id: string | number | null,
+    code: number,
+    message: string,
+    data?: any,
+  ) {
+    const response: JsonRpcResponse = {
+      jsonrpc: "2.0",
+      id,
+      error: { code, message, data },
+    };
     ws.send(JSON.stringify(response));
   }
 
   private sendNotification(ws: WebSocket, method: string, params: any) {
-    const notification = { jsonrpc: '2.0', method, params };
+    const notification = { jsonrpc: "2.0", method, params };
     ws.send(JSON.stringify(notification));
   }
 

--- a/src/operations/logging/chat-event-logger.ts
+++ b/src/operations/logging/chat-event-logger.ts
@@ -2,6 +2,7 @@ import { promises as fsp } from "fs";
 import * as os from "os";
 import * as path from "path";
 import { ModelResolutionSource } from "../../shared/types/chat";
+import { RoleName } from "../../domain/orchestration/entities/role";
 
 const DEFAULT_LOG_DIR = path.join(os.homedir(), ".multi-llm-agent-cli", "logs");
 const DEFAULT_LOG_FILE = "chat-events.jsonl";
@@ -20,13 +21,20 @@ export interface ChatEventLogEntry {
     | "context_clear"
     | "context_summarize"
     | "turn_completed"
-    | "turn_failed";
+    | "turn_failed"
+    | "role_delegation";
   model?: string;
   resolution_source?: ModelResolutionSource;
   user_input?: string;
   assistant_response?: string;
   duration_ms?: number;
   error_message?: string;
+  parent_task_id?: string;
+  child_task_id?: string;
+  delegated_role?: RoleName;
+  delegated_at?: string;
+  result_at?: string;
+  failure_reason?: string;
 }
 
 export type ChatEventLogger = (entry: ChatEventLogEntry) => Promise<void>;

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -1,0 +1,13 @@
+import { RoleName } from "../../domain/orchestration/entities/role";
+import { RoleTaskStatus } from "../../domain/orchestration/entities/task";
+
+export interface RoleDelegationEvent {
+  event_type: "role_delegation";
+  status: RoleTaskStatus;
+  task_id: string;
+  parent_task_id?: string;
+  delegated_role: RoleName;
+  delegated_at: string;
+  result_at?: string;
+  failure_reason?: string;
+}

--- a/src/tests/acceptance/features/F-101.role-definition.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-101.role-definition.acceptance.test.ts
@@ -1,5 +1,6 @@
 import { DispatchTaskUseCase } from "../../../application/orchestration/dispatch-task.usecase";
 import { RunRoleGraphUseCase } from "../../../application/orchestration/run-role-graph.usecase";
+import { RoleName } from "../../../domain/orchestration/entities/role";
 import { listRoleDefinitions } from "../../../domain/orchestration/entities/role";
 
 describe("F-101 Role Definition acceptance", () => {
@@ -18,7 +19,7 @@ describe("F-101 Role Definition acceptance", () => {
       () => ids.shift() ?? "task-extra",
     );
     const runRole = jest.fn(
-      async (role: string, prompt: string) => `${role}:${prompt}`,
+      async (role: RoleName, prompt: string) => `${role}:${prompt}`,
     );
     const useCase = new RunRoleGraphUseCase(dispatch, runRole);
 

--- a/src/tests/acceptance/features/F-101.role-definition.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-101.role-definition.acceptance.test.ts
@@ -1,0 +1,41 @@
+import { DispatchTaskUseCase } from "../../../application/orchestration/dispatch-task.usecase";
+import { RunRoleGraphUseCase } from "../../../application/orchestration/run-role-graph.usecase";
+import { listRoleDefinitions } from "../../../domain/orchestration/entities/role";
+
+describe("F-101 Role Definition acceptance", () => {
+  it("shows standard roles and records actually used role composition", async () => {
+    const roles = listRoleDefinitions();
+    expect(roles.map((role) => role.name)).toEqual([
+      "coordinator",
+      "developer",
+      "reviewer",
+      "documenter",
+    ]);
+
+    const ids = ["task-root", "task-dev", "task-review", "task-doc"];
+    const dispatch = new DispatchTaskUseCase(
+      () => "2026-02-22T02:00:00.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+    const runRole = jest.fn(
+      async (role: string, prompt: string) => `${role}:${prompt}`,
+    );
+    const useCase = new RunRoleGraphUseCase(dispatch, runRole);
+
+    const result = await useCase.execute("implement feature");
+    const usedRoles = result.tasks.map((task) => task.role);
+
+    expect(usedRoles).toEqual([
+      "coordinator",
+      "developer",
+      "reviewer",
+      "documenter",
+    ]);
+    expect(runRole.mock.calls.map((call) => call[0])).toEqual([
+      "coordinator",
+      "developer",
+      "reviewer",
+      "documenter",
+    ]);
+  });
+});

--- a/src/tests/acceptance/features/F-102.delegation-mcp.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-102.delegation-mcp.acceptance.test.ts
@@ -1,0 +1,72 @@
+import { promises as fsp } from "fs";
+import * as os from "os";
+import * as path from "path";
+import { McpServer } from "../../../mcp/McpServer";
+import { RoleDelegationEvent } from "../../../shared/types/events";
+
+describe("F-102 MCP delegation acceptance", () => {
+  let server: any;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "f102-mcp-"));
+    process.env.CHAT_EVENT_LOG_FILE = path.join(tempDir, "chat-events.jsonl");
+    server = Object.create(McpServer.prototype);
+    server.sendNotification = jest.fn();
+  });
+
+  afterEach(async () => {
+    delete process.env.CHAT_EVENT_LOG_FILE;
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("emits task_status_update with delegatedRole/parentTaskId/childTaskId", () => {
+    const ws = {};
+    const event: RoleDelegationEvent = {
+      event_type: "role_delegation",
+      status: "completed",
+      task_id: "task-child",
+      parent_task_id: "task-root",
+      delegated_role: "developer",
+      delegated_at: "2026-02-22T03:00:00.000Z",
+      result_at: "2026-02-22T03:00:01.000Z",
+    };
+
+    server.sendRoleDelegationNotification(ws, "task-root", event);
+
+    expect(server.sendNotification).toHaveBeenCalledWith(
+      ws,
+      "task_status_update",
+      expect.objectContaining({
+        taskId: "task-root",
+        parentTaskId: "task-root",
+        childTaskId: "task-child",
+        delegatedRole: "developer",
+      }),
+    );
+  });
+
+  it("persists role delegation audit log fields", async () => {
+    const event: RoleDelegationEvent = {
+      event_type: "role_delegation",
+      status: "failed",
+      task_id: "task-child",
+      parent_task_id: "task-root",
+      delegated_role: "reviewer",
+      delegated_at: "2026-02-22T03:10:00.000Z",
+      result_at: "2026-02-22T03:10:02.000Z",
+      failure_reason: "policy violation",
+    };
+
+    await server.writeRoleDelegationLog("task-root", event);
+
+    const logFile = process.env.CHAT_EVENT_LOG_FILE!;
+    const content = await fsp.readFile(logFile, "utf-8");
+    expect(content).toContain('"event_type":"role_delegation"');
+    expect(content).toContain('"session_id":"task-root"');
+    expect(content).toContain('"parent_task_id":"task-root"');
+    expect(content).toContain('"child_task_id":"task-child"');
+    expect(content).toContain('"delegated_role":"reviewer"');
+    expect(content).toContain('"failure_reason":"policy violation"');
+  });
+});

--- a/src/tests/acceptance/features/F-102.delegation.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-102.delegation.acceptance.test.ts
@@ -1,0 +1,72 @@
+import { DispatchTaskUseCase } from "../../../application/orchestration/dispatch-task.usecase";
+import { RunRoleGraphUseCase } from "../../../application/orchestration/run-role-graph.usecase";
+import { RoleDelegationEvent } from "../../../shared/types/events";
+
+describe("F-102 Role Delegation acceptance", () => {
+  it("tracks parent-child task consistency and delegation summary events", async () => {
+    const ids = ["task-root", "task-dev", "task-review", "task-doc"];
+    const dispatch = new DispatchTaskUseCase(
+      () => "2026-02-22T02:10:00.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+    const auditEvents: RoleDelegationEvent[] = [];
+    const useCase = new RunRoleGraphUseCase(
+      dispatch,
+      async (role: string, prompt: string) => `${role}:${prompt}`,
+      async (event) => {
+        auditEvents.push(event);
+      },
+    );
+
+    const result = await useCase.execute("implement feature");
+    const childTasks = result.tasks.filter(
+      (task) => task.parentTaskId === result.rootTaskId,
+    );
+
+    expect(childTasks).toHaveLength(3);
+    expect(
+      childTasks.every((task) => task.parentTaskId === result.rootTaskId),
+    ).toBe(true);
+    expect(auditEvents).toHaveLength(3);
+    expect(
+      auditEvents.every(
+        (event) =>
+          event.parent_task_id === result.rootTaskId &&
+          event.result_at !== undefined &&
+          event.failure_reason === undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it("records failure reason when delegated role fails", async () => {
+    const ids = ["task-root", "task-dev", "task-review"];
+    const dispatch = new DispatchTaskUseCase(
+      () => "2026-02-22T02:20:00.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+    const auditEvents: RoleDelegationEvent[] = [];
+    const useCase = new RunRoleGraphUseCase(
+      dispatch,
+      async (role: string, prompt: string) => {
+        if (role === "reviewer") {
+          throw new Error("policy violation");
+        }
+        return `${role}:${prompt}`;
+      },
+      async (event) => {
+        auditEvents.push(event);
+      },
+    );
+
+    await expect(useCase.execute("implement feature")).rejects.toThrow(
+      "policy violation",
+    );
+    expect(auditEvents[auditEvents.length - 1]).toEqual(
+      expect.objectContaining({
+        delegated_role: "reviewer",
+        status: "failed",
+        failure_reason: "policy violation",
+      }),
+    );
+  });
+});

--- a/src/tests/unit/application/dispatch-task.usecase.test.ts
+++ b/src/tests/unit/application/dispatch-task.usecase.test.ts
@@ -1,0 +1,109 @@
+import { DispatchTaskUseCase } from "../../../application/orchestration/dispatch-task.usecase";
+import {
+  isRoleName,
+  listRoleDefinitions,
+} from "../../../domain/orchestration/entities/role";
+
+describe("DispatchTaskUseCase", () => {
+  it("provides standard role definitions", () => {
+    const roles = listRoleDefinitions();
+
+    expect(roles.map((role) => role.name)).toEqual([
+      "coordinator",
+      "developer",
+      "reviewer",
+      "documenter",
+    ]);
+    expect(isRoleName("coordinator")).toBe(true);
+    expect(isRoleName("developer")).toBe(true);
+    expect(isRoleName("reviewer")).toBe(true);
+    expect(isRoleName("documenter")).toBe(true);
+    expect(isRoleName("unknown")).toBe(false);
+  });
+
+  it("tracks parent-child tasks and completion metadata", () => {
+    const times = [
+      "2026-02-22T00:00:00.000Z",
+      "2026-02-22T00:00:01.000Z",
+      "2026-02-22T00:00:02.000Z",
+      "2026-02-22T00:00:03.000Z",
+    ];
+    const ids = ["task-root", "task-child"];
+    const useCase = new DispatchTaskUseCase(
+      () => times.shift() ?? "2026-02-22T00:00:09.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+
+    const root = useCase.createRootTask("coordinator", "root prompt");
+    const child = useCase.delegateTask(root.taskId, "developer", "sub prompt");
+    useCase.markTaskRunning(child.taskId);
+    const completed = useCase.completeTask(child.taskId, "done");
+
+    expect(root.parentTaskId).toBeUndefined();
+    expect(child.parentTaskId).toBe(root.taskId);
+    expect(completed.status).toBe("completed");
+    expect(completed.output).toBe("done");
+    expect(completed.resultAt).toBe("2026-02-22T00:00:02.000Z");
+    expect(
+      useCase.listChildren(root.taskId).map((task) => task.taskId),
+    ).toEqual(["task-child"]);
+  });
+
+  it("preserves failure reason and task status on delegation failure", () => {
+    const times = [
+      "2026-02-22T00:10:00.000Z",
+      "2026-02-22T00:10:01.000Z",
+      "2026-02-22T00:10:02.000Z",
+    ];
+    const ids = ["task-root", "task-child"];
+    const useCase = new DispatchTaskUseCase(
+      () => times.shift() ?? "2026-02-22T00:10:09.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+
+    const root = useCase.createRootTask("coordinator", "root prompt");
+    const child = useCase.delegateTask(
+      root.taskId,
+      "reviewer",
+      "review prompt",
+    );
+    const failed = useCase.failTask(child.taskId, "tool timeout");
+
+    expect(failed.status).toBe("failed");
+    expect(failed.failureReason).toBe("tool timeout");
+    expect(failed.resultAt).toBe("2026-02-22T00:10:02.000Z");
+    expect(useCase.getTask(child.taskId)?.parentTaskId).toBe(root.taskId);
+  });
+
+  it("rejects delegation when parent task does not exist", () => {
+    const useCase = new DispatchTaskUseCase();
+
+    expect(() =>
+      useCase.delegateTask("missing-parent", "developer", "sub prompt"),
+    ).toThrow("Parent task not found");
+  });
+
+  it("rejects delegation when role policy does not allow it", () => {
+    const ids = ["task-root", "task-child"];
+    const useCase = new DispatchTaskUseCase(
+      () => "2026-02-22T00:20:00.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+    const root = useCase.createRootTask("documenter", "root prompt");
+
+    expect(() =>
+      useCase.delegateTask(root.taskId, "developer", "sub prompt"),
+    ).toThrow("Role delegation is not allowed");
+  });
+
+  it("uses collision-safe default task ids", () => {
+    const useCase = new DispatchTaskUseCase(() => "2026-02-22T00:30:00.000Z");
+    const root = useCase.createRootTask("coordinator", "root");
+    const child1 = useCase.delegateTask(root.taskId, "developer", "dev");
+    const child2 = useCase.delegateTask(root.taskId, "reviewer", "review");
+
+    expect(root.taskId).not.toEqual(child1.taskId);
+    expect(child1.taskId).not.toEqual(child2.taskId);
+    expect(root.taskId.startsWith("task-")).toBe(true);
+  });
+});

--- a/src/tests/unit/application/run-role-graph.usecase.test.ts
+++ b/src/tests/unit/application/run-role-graph.usecase.test.ts
@@ -1,0 +1,156 @@
+import { DispatchTaskUseCase } from "../../../application/orchestration/dispatch-task.usecase";
+import { RunRoleGraphUseCase } from "../../../application/orchestration/run-role-graph.usecase";
+
+describe("RunRoleGraphUseCase", () => {
+  it("delegates tasks across developer/reviewer/documenter and returns final output", async () => {
+    const times = [
+      "2026-02-22T01:00:00.000Z",
+      "2026-02-22T01:00:01.000Z",
+      "2026-02-22T01:00:02.000Z",
+      "2026-02-22T01:00:03.000Z",
+      "2026-02-22T01:00:04.000Z",
+      "2026-02-22T01:00:05.000Z",
+      "2026-02-22T01:00:06.000Z",
+      "2026-02-22T01:00:07.000Z",
+    ];
+    const ids = ["task-root", "task-dev", "task-review", "task-doc"];
+    const dispatch = new DispatchTaskUseCase(
+      () => times.shift() ?? "2026-02-22T01:00:09.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+    const runRole = jest.fn(async (role: string, prompt: string) => {
+      if (role === "developer") {
+        return `dev:${prompt}`;
+      }
+      if (role === "reviewer") {
+        return `review:${prompt}`;
+      }
+      return `doc:${prompt}`;
+    });
+    const useCase = new RunRoleGraphUseCase(dispatch, runRole);
+
+    const result = await useCase.execute("fix bug");
+
+    expect(result.finalResponse).toContain("doc:");
+    expect(runRole.mock.calls.map((call) => call[0])).toEqual([
+      "coordinator",
+      "developer",
+      "reviewer",
+      "documenter",
+    ]);
+    const childEvents = result.events.filter(
+      (event) => event.parent_task_id === result.rootTaskId,
+    );
+    expect(childEvents).toHaveLength(3);
+    expect(childEvents.map((event) => event.delegated_role)).toEqual([
+      "developer",
+      "reviewer",
+      "documenter",
+    ]);
+    expect(
+      result.tasks
+        .filter((task) => task.parentTaskId === result.rootTaskId)
+        .map((task) => task.taskId),
+    ).toEqual(["task-dev", "task-review", "task-doc"]);
+  });
+
+  it("marks child and root tasks failed when delegated role execution throws", async () => {
+    const ids = ["task-root", "task-dev", "task-review"];
+    const dispatch = new DispatchTaskUseCase(
+      () => "2026-02-22T01:10:00.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+    const runRole = jest.fn(async (role: string) => {
+      if (role === "reviewer") {
+        throw new Error("review failed");
+      }
+      return "ok";
+    });
+    const useCase = new RunRoleGraphUseCase(dispatch, runRole);
+
+    await expect(useCase.execute("fix bug")).rejects.toThrow("review failed");
+    const rootTask = dispatch.getTask("task-root");
+    const reviewerTask = dispatch.getTask("task-review");
+    expect(rootTask?.status).toBe("failed");
+    expect(reviewerTask?.status).toBe("failed");
+    expect(reviewerTask?.failureReason).toContain("review failed");
+  });
+
+  it("emits a root failure event when coordinator fails before child delegation", async () => {
+    const ids = ["task-root"];
+    const dispatch = new DispatchTaskUseCase(
+      () => "2026-02-22T01:15:00.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+    const onEvent = jest.fn();
+    const runRole = jest.fn(async (role: string) => {
+      if (role === "coordinator") {
+        throw new Error("coordinator failed");
+      }
+      return "ok";
+    });
+    const useCase = new RunRoleGraphUseCase(dispatch, runRole, onEvent);
+
+    await expect(useCase.execute("fix bug")).rejects.toThrow(
+      "coordinator failed",
+    );
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delegated_role: "coordinator",
+        status: "failed",
+        failure_reason: "coordinator failed",
+      }),
+    );
+    expect(dispatch.getTask("task-root")?.status).toBe("failed");
+  });
+
+  it("emits delegation events to audit logger callback", async () => {
+    const ids = ["task-root", "task-dev", "task-review", "task-doc"];
+    const dispatch = new DispatchTaskUseCase(
+      () => "2026-02-22T01:20:00.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+    const runRole = jest.fn(async (role: string, prompt: string) => {
+      return `${role}:${prompt}`;
+    });
+    const onEvent = jest.fn();
+    const useCase = new RunRoleGraphUseCase(dispatch, runRole, onEvent);
+
+    await useCase.execute("summarize");
+
+    expect(onEvent).toHaveBeenCalledTimes(3);
+    expect(onEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        event_type: "role_delegation",
+        delegated_role: "developer",
+      }),
+    );
+    expect(onEvent).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        event_type: "role_delegation",
+        delegated_role: "documenter",
+      }),
+    );
+  });
+
+  it("continues processing when audit callback throws", async () => {
+    const ids = ["task-root", "task-dev", "task-review", "task-doc"];
+    const dispatch = new DispatchTaskUseCase(
+      () => "2026-02-22T01:30:00.000Z",
+      () => ids.shift() ?? "task-extra",
+    );
+    const runRole = jest.fn(
+      async (role: string, prompt: string) => `${role}:${prompt}`,
+    );
+    const onEvent = jest.fn().mockRejectedValue(new Error("socket closed"));
+    const useCase = new RunRoleGraphUseCase(dispatch, runRole, onEvent);
+
+    const result = await useCase.execute("summarize");
+
+    expect(result.finalResponse).toContain("documenter:");
+    expect(onEvent).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/tests/unit/mcp/mcp.server.test.ts
+++ b/src/tests/unit/mcp/mcp.server.test.ts
@@ -1,0 +1,32 @@
+import { evaluateArithmeticExpression } from "../../../mcp/McpServer";
+
+describe("McpServer arithmetic evaluator", () => {
+  it("evaluates basic expressions with precedence", () => {
+    expect(evaluateArithmeticExpression("1 + 2 * 3")).toBe(7);
+    expect(evaluateArithmeticExpression("(1 + 2) * 3")).toBe(9);
+    expect(evaluateArithmeticExpression("7 / 2")).toBe(3.5);
+    expect(evaluateArithmeticExpression("-3 + 5")).toBe(2);
+    expect(evaluateArithmeticExpression("-(1+2)")).toBe(-3);
+  });
+
+  it("rejects unsupported characters and code injection payloads", () => {
+    expect(() => evaluateArithmeticExpression("process.exit(1)")).toThrow(
+      "Unsupported character",
+    );
+    expect(() =>
+      evaluateArithmeticExpression("1 + globalThis.constructor"),
+    ).toThrow("Unsupported character");
+  });
+
+  it("rejects invalid arithmetic inputs", () => {
+    expect(() => evaluateArithmeticExpression("")).toThrow(
+      "Expression is empty",
+    );
+    expect(() => evaluateArithmeticExpression("1 / 0")).toThrow(
+      "Division by zero",
+    );
+    expect(() => evaluateArithmeticExpression("(1 + 2")).toThrow(
+      "Mismatched parentheses",
+    );
+  });
+});

--- a/src/tests/unit/mcp/mcp.server.test.ts
+++ b/src/tests/unit/mcp/mcp.server.test.ts
@@ -7,6 +7,8 @@ describe("McpServer arithmetic evaluator", () => {
     expect(evaluateArithmeticExpression("7 / 2")).toBe(3.5);
     expect(evaluateArithmeticExpression("-3 + 5")).toBe(2);
     expect(evaluateArithmeticExpression("-(1+2)")).toBe(-3);
+    expect(evaluateArithmeticExpression(".5 + .5")).toBe(1);
+    expect(evaluateArithmeticExpression("5. + 0.5")).toBe(5.5);
   });
 
   it("rejects unsupported characters and code injection payloads", () => {

--- a/src/tests/unit/operations/chat-event-logger.test.ts
+++ b/src/tests/unit/operations/chat-event-logger.test.ts
@@ -111,4 +111,26 @@ describe("chat-event-logger", () => {
     expect(current).toContain('"event_type":"context_clear"');
     expect(current).toContain('"session_id":"s-1"');
   });
+
+  it("writes role delegation events with parent/child and timing fields", async () => {
+    const logFile = path.join(tempDir, "chat-events.jsonl");
+    process.env.CHAT_EVENT_LOG_FILE = logFile;
+
+    await writeChatEventLog({
+      timestamp: "2026-02-22T02:30:00.000Z",
+      session_id: "task-root",
+      event_type: "role_delegation",
+      parent_task_id: "task-root",
+      child_task_id: "task-dev",
+      delegated_role: "developer",
+      delegated_at: "2026-02-22T02:30:00.000Z",
+      result_at: "2026-02-22T02:30:01.000Z",
+    });
+
+    const current = await fsp.readFile(logFile, "utf-8");
+    expect(current).toContain('"event_type":"role_delegation"');
+    expect(current).toContain('"parent_task_id":"task-root"');
+    expect(current).toContain('"child_task_id":"task-dev"');
+    expect(current).toContain('"delegated_role":"developer"');
+  });
 });


### PR DESCRIPTION
## 概要 (Summary)
Issue #39 の S2.1（F-101/F-102）として、単一 Control Node 内でのロール実行モデルを実装しました。
ロール定義、親子タスク追跡、委譲可視化、監査ログ連携、受け入れテストを追加しています。

## 関連Issue (Related Issues)
Closes #39

## 変更の種類 (Type of Change)
- [x] 新機能 (New feature)
- [x] バグ修正 (Bug fix)
- [ ] リファクタリング (Refactoring)
- [x] ドキュメント更新 (Documentation)

## 詳細な変更点 (Detailed Changes)
- `src/domain/orchestration/entities/role.ts`: 標準ロール定義と委譲可能先ポリシーを追加。
- `src/domain/orchestration/entities/task.ts`: 親子タスクモデルと状態フィールドを追加。
- `src/application/orchestration/dispatch-task.usecase.ts`: 親子タスク生成・状態遷移・失敗理由保持を実装。
- `src/application/orchestration/run-role-graph.usecase.ts`: coordinator→developer→reviewer→documenter フロー、失敗時イベント、監査イベント連携を実装。
- `src/mcp/McpServer.ts`: role graph 実行接続、委譲通知、監査ログ書込、完了/失敗通知整合を実装。
- `src/mcp/McpServer.ts`: calculator ツールの `eval` を撤廃し、安全な四則演算パーサへ置換。
- `src/operations/logging/chat-event-logger.ts`: `role_delegation` イベント型を追加。
- `src/tests/...`: F-101/F-102 の unit/acceptance テスト、MCP連携テスト、演算パーサ回帰テストを追加。
- `README.md`: F-101/F-102 MVP 制約と可視化項目を追記。

## 動作確認手順 (Verification Steps)
1. `npm run lint`
2. `npm test`

## 自己チェック (Self Check)
- [x] 既存のテストを壊していないか
- [x] 機密情報（API Key等）が含まれていないか
