### PR TITLE
feat: add MCP management commands and logging for #41

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ local.*.md
 .git_commit_message.txt
 temp_commit_message.txt
 .serena/
+checkpoint/
 
 !jest.config.js
 

--- a/src/adapters/config/file-config.adapter.ts
+++ b/src/adapters/config/file-config.adapter.ts
@@ -1,18 +1,19 @@
-import * as fs from 'fs';
-import { promises as fsp } from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { ConfigPort } from '../../ports/outbound/config.port';
+import * as fs from "fs";
+import { promises as fsp } from "fs";
+import * as os from "os";
+import * as path from "path";
+import { ConfigPort, McpToolStates } from "../../ports/outbound/config.port";
 
 interface StoredConfig {
   defaultModel?: string;
+  mcpTools?: McpToolStates;
 }
 
-const CONFIG_DIR = path.join(os.homedir(), '.multi-llm-agent-cli');
-const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
+const CONFIG_DIR = path.join(os.homedir(), ".multi-llm-agent-cli");
+const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
 
 export class FileConfigAdapter implements ConfigPort {
-  constructor(private readonly fallbackModel: string = 'llama2') {}
+  constructor(private readonly fallbackModel: string = "llama2") {}
 
   async getDefaultModel(): Promise<string> {
     const envModel = process.env.DEFAULT_MODEL?.trim();
@@ -32,7 +33,26 @@ export class FileConfigAdapter implements ConfigPort {
     };
 
     await fsp.mkdir(CONFIG_DIR, { recursive: true });
-    await fsp.writeFile(CONFIG_FILE, JSON.stringify(next, null, 2), 'utf-8');
+    await fsp.writeFile(CONFIG_FILE, JSON.stringify(next, null, 2), "utf-8");
+  }
+
+  async getMcpToolStates(): Promise<McpToolStates> {
+    const data = await this.readConfig();
+    return { ...(data.mcpTools ?? {}) };
+  }
+
+  async setMcpToolEnabled(toolName: string, enabled: boolean): Promise<void> {
+    const current = await this.readConfig();
+    const next: StoredConfig = {
+      ...current,
+      mcpTools: {
+        ...(current.mcpTools ?? {}),
+        [toolName]: enabled,
+      },
+    };
+
+    await fsp.mkdir(CONFIG_DIR, { recursive: true });
+    await fsp.writeFile(CONFIG_FILE, JSON.stringify(next, null, 2), "utf-8");
   }
 
   private async readConfig(): Promise<StoredConfig> {
@@ -41,13 +61,13 @@ export class FileConfigAdapter implements ConfigPort {
         return {};
       }
 
-      const raw = await fsp.readFile(CONFIG_FILE, 'utf-8');
+      const raw = await fsp.readFile(CONFIG_FILE, "utf-8");
       return JSON.parse(raw) as StoredConfig;
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         return {};
       }
-      console.error('設定ファイルの読み込みに失敗しました:', error);
+      console.error("設定ファイルの読み込みに失敗しました:", error);
       return {};
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { randomUUID } from "crypto";
 import * as os from "os";
 import * as path from "path";
+import { McpServer } from "./mcp/McpServer";
 import { RunChatUseCase } from "./application/chat/run-chat.usecase";
 import { ResolveModelUseCase } from "./application/model-endpoint/resolve-model.usecase";
 import { FileConfigAdapter } from "./adapters/config/file-config.adapter";
@@ -11,6 +12,7 @@ import { FileSessionStoreAdapter } from "./adapters/session/file-session-store.a
 import { runChatCommand } from "./interaction/cli/commands/chat.command";
 import {
   ChatEventLogEntry,
+  readLatestMcpToolEntries,
   writeChatEventLog,
 } from "./operations/logging/chat-event-logger";
 import { LlmClientPort } from "./ports/outbound/llm-client.port";
@@ -30,6 +32,15 @@ const SESSION_STORAGE_PATH = path.join(
     path.join(os.homedir(), ".multi-llm-agent-cli"),
   "session.json",
 );
+const MCP_ADMIN_SESSION_ID = "mcp-admin";
+
+type McpToolView = {
+  name: string;
+  enabled: boolean;
+  callCount?: number;
+  lastSuccess?: boolean;
+  lastCalledAt?: string;
+};
 
 export function createProgram(deps?: {
   useCase?: RunChatUseCase;
@@ -62,6 +73,56 @@ export function createProgram(deps?: {
     } catch {
       // Logging must never break command execution.
     }
+  };
+  let mcpHistoryPromise: Promise<Map<string, ChatEventLogEntry>> | null = null;
+  const loadMcpToolHistory = async (): Promise<
+    Map<string, ChatEventLogEntry>
+  > => {
+    if (!mcpHistoryPromise) {
+      mcpHistoryPromise = (async () => {
+        try {
+          return await readLatestMcpToolEntries();
+        } catch {
+          // Log inspection must not block MCP admin operations.
+          return new Map<string, ChatEventLogEntry>();
+        }
+      })();
+    }
+
+    return mcpHistoryPromise;
+  };
+  const loadMcpToolViews = async (): Promise<McpToolView[]> => {
+    const states = await config.getMcpToolStates();
+    const lastToolEntries = await loadMcpToolHistory();
+
+    return McpServer.createToolSnapshot(states).map((tool) => {
+      const lastEntry = lastToolEntries.get(tool.name);
+      return {
+        name: tool.name,
+        enabled: tool.enabled,
+        callCount: lastEntry?.mcp_call_count,
+        lastSuccess: lastEntry?.mcp_success,
+        lastCalledAt: lastEntry?.timestamp,
+      };
+    });
+  };
+  const getMcpToolView = async (toolName: string): Promise<McpToolView> => {
+    const tools = await loadMcpToolViews();
+    const tool = tools.find((item) => item.name === toolName);
+    if (!tool) {
+      throw new Error(`Tool not found: ${toolName}`);
+    }
+    return tool;
+  };
+  const printMcpToolList = (heading: string, tools: McpToolView[]): void => {
+    console.log(heading);
+    if (tools.length === 0) {
+      console.log("  (none)");
+      return;
+    }
+    tools.forEach((tool) => {
+      console.log(`  - ${tool.name}: ${tool.enabled ? "enabled" : "disabled"}`);
+    });
   };
 
   const program = new Command();
@@ -146,6 +207,102 @@ export function createProgram(deps?: {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`モデル設定に失敗しました: ${message}`);
+      }
+    });
+
+  const mcpCommand = program
+    .command("mcp")
+    .description("MCP tool management operations.");
+
+  mcpCommand
+    .command("list")
+    .description("List known MCP tools and their status.")
+    .action(async () => {
+      try {
+        const tools = await loadMcpToolViews();
+        printMcpToolList("MCPツール一覧:", tools);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`MCPツール一覧の取得に失敗しました: ${message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  mcpCommand
+    .command("status [tool_name]")
+    .description("Show MCP tool status.")
+    .action(async (toolName?: string) => {
+      try {
+        if (toolName) {
+          const tool = await getMcpToolView(toolName);
+          console.log(`tool=${toolName}`);
+          console.log(`status=${tool.enabled ? "enabled" : "disabled"}`);
+          console.log(`call_count=${tool.callCount ?? 0}`);
+          console.log(
+            `last_success=${
+              tool.lastSuccess === undefined
+                ? "unknown"
+                : tool.lastSuccess
+                  ? "yes"
+                  : "no"
+            }`,
+          );
+          console.log(`last_called_at=${tool.lastCalledAt ?? "never"}`);
+          return;
+        }
+
+        const tools = await loadMcpToolViews();
+        printMcpToolList("MCPステータス:", tools);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`MCPステータスの取得に失敗しました: ${message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  mcpCommand
+    .command("enable <tool_name>")
+    .description("Enable an MCP tool.")
+    .action(async (toolName: string) => {
+      try {
+        const tool = await getMcpToolView(toolName);
+        await config.setMcpToolEnabled(toolName, true);
+        console.log(`MCPツールを有効化しました: ${toolName}`);
+        await logSessionEvent(true, {
+          session_id: MCP_ADMIN_SESSION_ID,
+          event_type: "mcp_tool_state_change",
+          mcp_tool_name: toolName,
+          mcp_previous_enabled: tool.enabled,
+          mcp_enabled: true,
+        });
+        mcpHistoryPromise = null;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`MCPツールの有効化に失敗しました: ${message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  mcpCommand
+    .command("disable <tool_name>")
+    .description("Disable an MCP tool.")
+    .action(async (toolName: string) => {
+      try {
+        const tool = await getMcpToolView(toolName);
+        await config.setMcpToolEnabled(toolName, false);
+        console.log(`MCPツールを無効化しました: ${toolName}`);
+        await logSessionEvent(true, {
+          session_id: MCP_ADMIN_SESSION_ID,
+          event_type: "mcp_tool_state_change",
+          mcp_tool_name: toolName,
+          mcp_previous_enabled: tool.enabled,
+          mcp_enabled: false,
+        });
+        mcpHistoryPromise = null;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`MCPツールの無効化に失敗しました: ${message}`);
+        process.exitCode = 1;
       }
     });
 

--- a/src/mcp/McpClient.ts
+++ b/src/mcp/McpClient.ts
@@ -1,14 +1,14 @@
-import WebSocket from 'ws';
+import * as readline from "readline";
 
 interface JsonRpcRequest {
-  jsonrpc: '2.0';
+  jsonrpc: "2.0";
   id: string | number;
   method: string;
   params?: any;
 }
 
 interface JsonRpcResponse {
-  jsonrpc: '2.0';
+  jsonrpc: "2.0";
   id: string | number | null;
   result?: any;
   error?: {
@@ -16,57 +16,69 @@ interface JsonRpcResponse {
     message: string;
     data?: any;
   };
+  method?: string;
+  params?: any;
 }
 
 export class McpClient {
-  private ws: WebSocket | null = null;
-  private url: string;
-  private messageIdCounter: number = 0;
-  private pendingRequests = new Map<number, { resolve: (value: any) => void; reject: (reason?: any) => void }>();
+  private input: NodeJS.ReadableStream;
+  private output: NodeJS.WritableStream;
+  private reader: readline.Interface | null = null;
+  private messageIdCounter = 0;
+  private pendingRequests = new Map<
+    number,
+    { resolve: (value: any) => void; reject: (reason?: any) => void }
+  >();
 
-  constructor(url: string = 'ws://localhost:8080') {
-    this.url = url;
+  constructor(
+    input: NodeJS.ReadableStream = process.stdin,
+    output: NodeJS.WritableStream = process.stdout,
+  ) {
+    this.input = input;
+    this.output = output;
   }
 
   public connect(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.ws = new WebSocket(this.url);
+    if (this.reader) {
+      return Promise.resolve();
+    }
 
-      this.ws.onopen = () => {
-        console.log('Connected to MCP Server');
-        resolve();
-      };
-
-      this.ws.onmessage = event => {
-        this.handleMessage(event.data.toString());
-      };
-
-      this.ws.onclose = () => {
-        console.log('Disconnected from MCP Server');
-      };
-
-      this.ws.onerror = error => {
-        console.error('WebSocket error:', error);
-        reject(error);
-      };
+    this.reader = readline.createInterface({
+      input: this.input,
+      crlfDelay: Infinity,
     });
+
+    this.reader.on("line", (line) => {
+      const message = line.trim();
+      if (!message) {
+        return;
+      }
+      this.handleMessage(message);
+    });
+
+    this.reader.on("error", (error) => {
+      for (const pending of this.pendingRequests.values()) {
+        pending.reject(error);
+      }
+      this.pendingRequests.clear();
+    });
+
+    return Promise.resolve();
   }
 
   public disconnect(): void {
-    if (this.ws) {
-      this.ws.close();
-      this.ws = null;
-    }
+    this.reader?.close();
+    this.reader = null;
   }
 
   public async sendRequest(method: string, params?: any): Promise<any> {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      throw new Error('WebSocket is not connected.');
+    if (!this.reader) {
+      throw new Error("stdio is not connected.");
     }
 
     const id = this.messageIdCounter++;
     const request: JsonRpcRequest = {
-      jsonrpc: '2.0',
+      jsonrpc: "2.0",
       id,
       method,
       params,
@@ -74,7 +86,7 @@ export class McpClient {
 
     return new Promise((resolve, reject) => {
       this.pendingRequests.set(id, { resolve, reject });
-      this.ws?.send(JSON.stringify(request));
+      this.output.write(`${JSON.stringify(request)}\n`);
     });
   }
 
@@ -83,26 +95,27 @@ export class McpClient {
       const response: JsonRpcResponse = JSON.parse(message);
 
       if (response.id !== undefined && response.id !== null) {
-        // This is a response to a request
         const pending = this.pendingRequests.get(response.id as number);
-        if (pending) {
-          if (response.error) {
-            pending.reject(response.error);
-          } else {
-            pending.resolve(response.result);
-          }
-          this.pendingRequests.delete(response.id as number);
+        if (!pending) {
+          return;
         }
-      } else {
-        // This might be a notification (a request without an id)
-        const notification = response as JsonRpcRequest;
-        if (notification.method) {
-          console.log(`Received notification: ${notification.method} with params:`, notification.params);
-          // Handle notifications here (e.g., 'initialized', 'notifications/roots/list_changed')
+        if (response.error) {
+          pending.reject(response.error);
+        } else {
+          pending.resolve(response.result);
         }
+        this.pendingRequests.delete(response.id as number);
+        return;
+      }
+
+      if (response.method) {
+        console.log(
+          `Received notification: ${response.method} with params:`,
+          response.params,
+        );
       }
     } catch (error) {
-      console.error('Error parsing message:', error);
+      console.error("Error parsing message:", error);
     }
   }
 }

--- a/src/mcp/McpServer.ts
+++ b/src/mcp/McpServer.ts
@@ -192,6 +192,7 @@ type ToolFunction = (...args: any[]) => Promise<any>;
 const PLUGIN_DIR = path.join(os.homedir(), ".multi-llm-agent-cli", "plugins");
 const MCP_SERVER_SESSION_ID = "mcp-server";
 const MCP_SERVER_NAME = "local-control-node";
+const MCP_SERVER_HOST = "127.0.0.1";
 
 export class McpServer {
   private wss: WebSocketServer;
@@ -208,42 +209,9 @@ export class McpServer {
     return ["calculator"];
   }
 
-  static discoverRegisteredToolNames(): string[] {
-    const names = new Set<string>(McpServer.getBuiltinToolNames());
-
-    if (!fs.existsSync(PLUGIN_DIR)) {
-      return Array.from(names).sort((a, b) => a.localeCompare(b));
-    }
-
-    const pluginFiles = fs
-      .readdirSync(PLUGIN_DIR)
-      .filter((file) => file.endsWith(".js"));
-
-    for (const file of pluginFiles) {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const plugin = require(path.join(PLUGIN_DIR, file));
-        if (plugin?.name && typeof plugin.name === "string") {
-          names.add(plugin.name);
-        }
-        if (typeof plugin?.register === "function") {
-          plugin.register({
-            registerTool(name: string) {
-              names.add(name);
-            },
-          });
-        }
-      } catch {
-        // Ignore plugin parse errors during discovery.
-      }
-    }
-
-    return Array.from(names).sort((a, b) => a.localeCompare(b));
-  }
-
   static createToolSnapshot(
     states: Record<string, boolean>,
-    registeredToolNames: string[] = McpServer.discoverRegisteredToolNames(),
+    registeredToolNames: string[] = McpServer.getBuiltinToolNames(),
   ): Array<{ name: string; enabled: boolean }> {
     const names = new Set<string>([
       ...registeredToolNames,
@@ -258,8 +226,56 @@ export class McpServer {
       }));
   }
 
+  private static isLoopbackAddress(address?: string): boolean {
+    return (
+      address === undefined ||
+      address === "::1" ||
+      address === "::ffff:127.0.0.1" ||
+      address === MCP_SERVER_HOST
+    );
+  }
+
+  private static isTrustedOrigin(origin?: string): boolean {
+    if (!origin) {
+      return true;
+    }
+
+    try {
+      const parsed = new URL(origin);
+      return (
+        parsed.hostname === "localhost" ||
+        parsed.hostname === "::1" ||
+        parsed.hostname === MCP_SERVER_HOST
+      );
+    } catch {
+      return false;
+    }
+  }
+
   constructor(config: ConfigPort, port: number = 8080) {
-    this.wss = new WebSocketServer({ port });
+    this.wss = new WebSocketServer({
+      host: MCP_SERVER_HOST,
+      port,
+      verifyClient: (info: {
+        origin?: string;
+        req: { socket: { remoteAddress?: string } };
+      }) => {
+        const { origin, req } = info;
+        if (!McpServer.isLoopbackAddress(req.socket.remoteAddress)) {
+          logger.warn(
+            `Rejected non-loopback MCP connection from ${req.socket.remoteAddress ?? "unknown"}`,
+          );
+          return false;
+        }
+        if (!McpServer.isTrustedOrigin(origin)) {
+          logger.warn(
+            `Rejected MCP connection from untrusted origin: ${origin}`,
+          );
+          return false;
+        }
+        return true;
+      },
+    });
     this.orchestratorLLM = new OllamaClient(); // 指示者LLM
     this.workerLLM = new OllamaClient(); // 作業者LLM
     this.config = config;
@@ -276,7 +292,7 @@ export class McpServer {
 
     this.loadPlugins(); // プラグインをロード
 
-    logger.info(`MCP Server started on ws://localhost:${port}`);
+    logger.info(`MCP Server started on ws://${MCP_SERVER_HOST}:${port}`);
 
     this.wss.on("connection", (ws) => {
       logger.info("Client connected");
@@ -306,12 +322,22 @@ export class McpServer {
 
   public async listTools(): Promise<Array<{ name: string; enabled: boolean }>> {
     const states = await this.config.getMcpToolStates();
-    return McpServer.createToolSnapshot({
-      ...Object.fromEntries(
-        Array.from(this.tools.keys()).map((toolName) => [toolName, true]),
-      ),
-      ...states,
-    });
+    const registeredToolNames = Array.from(
+      new Set<string>([
+        ...McpServer.getBuiltinToolNames(),
+        ...Array.from(this.tools.keys()),
+      ]),
+    ).sort((a, b) => a.localeCompare(b));
+
+    return McpServer.createToolSnapshot(
+      {
+        ...Object.fromEntries(
+          Array.from(this.tools.keys()).map((toolName) => [toolName, true]),
+        ),
+        ...states,
+      },
+      registeredToolNames,
+    );
   }
 
   private async isToolEnabled(toolName: string): Promise<boolean> {
@@ -372,18 +398,26 @@ export class McpServer {
     }
 
     this.toolCallCountsLoadPromise = (async () => {
-      const entries = await readLatestMcpToolEntries();
-      entries.forEach((entry, toolName) => {
-        if (typeof entry.mcp_call_count !== "number") {
-          return;
-        }
-        const current = this.toolCallCounts.get(toolName) ?? 0;
-        this.toolCallCounts.set(
-          toolName,
-          Math.max(current, entry.mcp_call_count),
+      try {
+        const entries = await readLatestMcpToolEntries();
+        entries.forEach((entry, toolName) => {
+          if (typeof entry.mcp_call_count !== "number") {
+            return;
+          }
+          const current = this.toolCallCounts.get(toolName) ?? 0;
+          this.toolCallCounts.set(
+            toolName,
+            Math.max(current, entry.mcp_call_count),
+          );
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn(
+          `Failed to load previous MCP tool entries; proceeding with empty counts: ${message}`,
         );
-      });
-      this.toolCallCountsLoaded = true;
+      } finally {
+        this.toolCallCountsLoaded = true;
+      }
     })();
 
     try {

--- a/src/mcp/McpServer.ts
+++ b/src/mcp/McpServer.ts
@@ -1,8 +1,8 @@
-import { WebSocketServer, WebSocket } from "ws";
 import { OllamaClient, Message } from "../ollama/OllamaClient";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import * as readline from "readline";
 import { logger } from "../utils/logger";
 import { DispatchTaskUseCase } from "../application/orchestration/dispatch-task.usecase";
 import { RunRoleGraphUseCase } from "../application/orchestration/run-role-graph.usecase";
@@ -192,10 +192,18 @@ type ToolFunction = (...args: any[]) => Promise<any>;
 const PLUGIN_DIR = path.join(os.homedir(), ".multi-llm-agent-cli", "plugins");
 const MCP_SERVER_SESSION_ID = "mcp-server";
 const MCP_SERVER_NAME = "local-control-node";
-const MCP_SERVER_HOST = "127.0.0.1";
+
+interface RpcConnection {
+  send(payload: string): void;
+}
 
 export class McpServer {
-  private wss: WebSocketServer;
+  private stdinReader: readline.Interface | null = null;
+  private stdioConnection: RpcConnection = {
+    send(payload: string) {
+      process.stdout.write(`${payload}\n`);
+    },
+  };
   private orchestratorLLM: OllamaClient;
   private workerLLM: OllamaClient;
   private tasks: Map<string, Task> = new Map(); // タスクの状態管理
@@ -226,56 +234,7 @@ export class McpServer {
       }));
   }
 
-  private static isLoopbackAddress(address?: string): boolean {
-    return (
-      address === undefined ||
-      address === "::1" ||
-      address === "::ffff:127.0.0.1" ||
-      address === MCP_SERVER_HOST
-    );
-  }
-
-  private static isTrustedOrigin(origin?: string): boolean {
-    if (!origin) {
-      return true;
-    }
-
-    try {
-      const parsed = new URL(origin);
-      return (
-        parsed.hostname === "localhost" ||
-        parsed.hostname === "::1" ||
-        parsed.hostname === MCP_SERVER_HOST
-      );
-    } catch {
-      return false;
-    }
-  }
-
-  constructor(config: ConfigPort, port: number = 8080) {
-    this.wss = new WebSocketServer({
-      host: MCP_SERVER_HOST,
-      port,
-      verifyClient: (info: {
-        origin?: string;
-        req: { socket: { remoteAddress?: string } };
-      }) => {
-        const { origin, req } = info;
-        if (!McpServer.isLoopbackAddress(req.socket.remoteAddress)) {
-          logger.warn(
-            `Rejected non-loopback MCP connection from ${req.socket.remoteAddress ?? "unknown"}`,
-          );
-          return false;
-        }
-        if (!McpServer.isTrustedOrigin(origin)) {
-          logger.warn(
-            `Rejected MCP connection from untrusted origin: ${origin}`,
-          );
-          return false;
-        }
-        return true;
-      },
-    });
+  constructor(config: ConfigPort, _legacyPort?: number) {
     this.orchestratorLLM = new OllamaClient(); // 指示者LLM
     this.workerLLM = new OllamaClient(); // 作業者LLM
     this.config = config;
@@ -292,27 +251,8 @@ export class McpServer {
 
     this.loadPlugins(); // プラグインをロード
 
-    logger.info(`MCP Server started on ws://${MCP_SERVER_HOST}:${port}`);
-
-    this.wss.on("connection", (ws) => {
-      logger.info("Client connected");
-
-      ws.on("message", (message) => {
-        this.handleMessage(ws, message.toString());
-      });
-
-      ws.on("close", () => {
-        logger.info("Client disconnected");
-      });
-
-      ws.on("error", (error) => {
-        logger.error("WebSocket error:", error);
-      });
-    });
-
-    this.wss.on("error", (error) => {
-      logger.error("WebSocket server error:", error);
-    });
+    this.startStdioTransport();
+    logger.info("MCP Server started on stdio transport");
   }
 
   private registerTool(name: string, func: ToolFunction) {
@@ -462,12 +402,36 @@ export class McpServer {
     }
   }
 
-  private async handleMessage(ws: WebSocket, message: string) {
+  private startStdioTransport(): void {
+    this.stdinReader = readline.createInterface({
+      input: process.stdin,
+      crlfDelay: Infinity,
+    });
+
+    this.stdinReader.on("line", (line) => {
+      const message = line.trim();
+      if (!message) {
+        return;
+      }
+      void this.handleMessage(this.stdioConnection, message);
+    });
+
+    this.stdinReader.on("error", (error) => {
+      logger.error("stdio transport error:", error);
+    });
+  }
+
+  private async handleMessage(connection: RpcConnection, message: string) {
     try {
       const request: JsonRpcRequest = JSON.parse(message);
 
       if (request.jsonrpc !== "2.0" || !request.method) {
-        this.sendError(ws, request.id || null, -32600, "Invalid Request");
+        this.sendError(
+          connection,
+          request.id || null,
+          -32600,
+          "Invalid Request",
+        );
         return;
       }
 
@@ -475,13 +439,13 @@ export class McpServer {
       switch (request.method) {
         case "initialize":
           result = { capabilities: {} }; // Basic capabilities for now
-          this.sendResponse(ws, request.id, result);
+          this.sendResponse(connection, request.id, result);
           // Send initialized notification
-          this.sendNotification(ws, "initialized", {});
+          this.sendNotification(connection, "initialized", {});
           break;
         case "roots/list":
           result = { roots: [] }; // No roots for now
-          this.sendResponse(ws, request.id, result);
+          this.sendResponse(connection, request.id, result);
           break;
         case "orchestrate/task": // 新しいメソッド: オーケストレーションタスクの開始
           const userPrompt = request.params.prompt;
@@ -492,9 +456,9 @@ export class McpServer {
             status: "pending",
           });
 
-          this.runOrchestration(taskId, userPrompt, ws) // WebSocketを渡して進捗を通知できるようにする
+          this.runOrchestration(taskId, userPrompt, connection)
             .then((finalResponse) => {
-              this.sendResponse(ws, request.id, {
+              this.sendResponse(connection, request.id, {
                 response: finalResponse,
                 taskId: taskId,
               });
@@ -505,13 +469,13 @@ export class McpServer {
                 error instanceof Error ? error.message : String(error);
               logger.error(`Orchestration failed for task ${taskId}:`, error);
               this.sendError(
-                ws,
+                connection,
                 request.id,
                 -32000,
                 `Orchestration failed: ${errorMessage}`,
               );
               this.tasks.get(taskId)!.status = "failed";
-              this.sendNotification(ws, "task_status_update", {
+              this.sendNotification(connection, "task_status_update", {
                 taskId,
                 status: "failed",
                 message: `Orchestration failed: ${errorMessage}`,
@@ -520,7 +484,7 @@ export class McpServer {
           break;
         default:
           this.sendError(
-            ws,
+            connection,
             request.id,
             -32601,
             `Method not found: ${request.method}`,
@@ -529,18 +493,18 @@ export class McpServer {
       }
     } catch (error) {
       logger.error("Error parsing message or handling request:", error);
-      this.sendError(ws, null, -32700, "Parse error");
+      this.sendError(connection, null, -32700, "Parse error");
     }
   }
 
   private async runOrchestration(
     taskId: string,
     userPrompt: string,
-    ws: WebSocket,
+    connection: RpcConnection,
   ): Promise<string> {
     const task = this.tasks.get(taskId)!;
     task.status = "orchestrating";
-    this.sendNotification(ws, "task_status_update", {
+    this.sendNotification(connection, "task_status_update", {
       taskId,
       status: task.status,
       message:
@@ -551,9 +515,9 @@ export class McpServer {
     const roleGraph = new RunRoleGraphUseCase(
       dispatchTask,
       (role, prompt, signal) =>
-        this.executeRole(role, prompt, taskId, ws, signal),
+        this.executeRole(role, prompt, taskId, connection, signal),
       async (event) => {
-        this.sendRoleDelegationNotification(ws, taskId, event);
+        this.sendRoleDelegationNotification(connection, taskId, event);
         try {
           await this.writeRoleDelegationLog(taskId, event);
         } catch (error: any) {
@@ -563,7 +527,7 @@ export class McpServer {
             `Role delegation audit log write failed for task ${taskId}:`,
             message,
           );
-          this.sendNotification(ws, "task_status_update", {
+          this.sendNotification(connection, "task_status_update", {
             taskId,
             status: event.status,
             message: `Audit log write failed: ${message}`,
@@ -583,7 +547,7 @@ export class McpServer {
     task.roleComposition = result.tasks.map((roleTask) => roleTask.role);
     task.delegationEvents = result.events;
     task.finalResponse = result.finalResponse;
-    this.sendNotification(ws, "task_status_update", {
+    this.sendNotification(connection, "task_status_update", {
       taskId,
       status: task.status,
       message: `Role execution completed: ${task.roleComposition.join(" -> ")}`,
@@ -596,7 +560,7 @@ export class McpServer {
     role: RoleName,
     prompt: string,
     taskId: string,
-    ws: WebSocket,
+    connection: RpcConnection,
     signal?: AbortSignal,
   ): Promise<string> {
     const client =
@@ -627,7 +591,7 @@ export class McpServer {
     }
     const toolName = toolCallMatch[1].trim();
     const toolArgs = toolCallMatch[2].trim();
-    this.sendNotification(ws, "task_status_update", {
+    this.sendNotification(connection, "task_status_update", {
       taskId,
       status: "working",
       message: `Role ${role} requested tool: ${toolName}(${toolArgs})`,
@@ -655,7 +619,7 @@ export class McpServer {
   }
 
   private sendRoleDelegationNotification(
-    ws: WebSocket,
+    connection: RpcConnection,
     taskId: string,
     event: RoleDelegationEvent,
   ) {
@@ -671,7 +635,7 @@ export class McpServer {
       event.status === "failed"
         ? `Delegated to ${event.delegated_role} failed: ${event.failure_reason ?? "unknown error"}`
         : `Delegated to ${event.delegated_role} completed`;
-    this.sendNotification(ws, "task_status_update", {
+    this.sendNotification(connection, "task_status_update", {
       taskId,
       parentTaskId: event.parent_task_id,
       childTaskId: event.task_id,
@@ -710,13 +674,17 @@ export class McpServer {
     });
   }
 
-  private sendResponse(ws: WebSocket, id: string | number, result: any) {
+  private sendResponse(
+    connection: RpcConnection,
+    id: string | number,
+    result: any,
+  ) {
     const response: JsonRpcResponse = { jsonrpc: "2.0", id, result };
-    ws.send(JSON.stringify(response));
+    connection.send(JSON.stringify(response));
   }
 
   private sendError(
-    ws: WebSocket,
+    connection: RpcConnection,
     id: string | number | null,
     code: number,
     message: string,
@@ -727,15 +695,20 @@ export class McpServer {
       id,
       error: { code, message, data },
     };
-    ws.send(JSON.stringify(response));
+    connection.send(JSON.stringify(response));
   }
 
-  private sendNotification(ws: WebSocket, method: string, params: any) {
+  private sendNotification(
+    connection: RpcConnection,
+    method: string,
+    params: any,
+  ) {
     const notification = { jsonrpc: "2.0", method, params };
-    ws.send(JSON.stringify(notification));
+    connection.send(JSON.stringify(notification));
   }
 
   public close() {
-    this.wss.close();
+    this.stdinReader?.close();
+    this.stdinReader = null;
   }
 }

--- a/src/mcp/McpServer.ts
+++ b/src/mcp/McpServer.ts
@@ -8,7 +8,11 @@ import { DispatchTaskUseCase } from "../application/orchestration/dispatch-task.
 import { RunRoleGraphUseCase } from "../application/orchestration/run-role-graph.usecase";
 import { RoleName } from "../domain/orchestration/entities/role";
 import { RoleDelegationEvent } from "../shared/types/events";
-import { writeChatEventLog } from "../operations/logging/chat-event-logger";
+import {
+  readLatestMcpToolEntries,
+  writeChatEventLog,
+} from "../operations/logging/chat-event-logger";
+import { ConfigPort } from "../ports/outbound/config.port";
 
 type ArithmeticToken =
   | { kind: "number"; value: number }
@@ -186,6 +190,8 @@ interface Task {
 type ToolFunction = (...args: any[]) => Promise<any>;
 
 const PLUGIN_DIR = path.join(os.homedir(), ".multi-llm-agent-cli", "plugins");
+const MCP_SERVER_SESSION_ID = "mcp-server";
+const MCP_SERVER_NAME = "local-control-node";
 
 export class McpServer {
   private wss: WebSocketServer;
@@ -193,11 +199,70 @@ export class McpServer {
   private workerLLM: OllamaClient;
   private tasks: Map<string, Task> = new Map(); // タスクの状態管理
   private tools: Map<string, ToolFunction> = new Map(); // 登録されたツール
+  private config: ConfigPort;
+  private toolCallCounts: Map<string, number> = new Map();
+  private toolCallCountsLoaded = false;
+  private toolCallCountsLoadPromise: Promise<void> | null = null;
 
-  constructor(port: number = 8080) {
+  static getBuiltinToolNames(): string[] {
+    return ["calculator"];
+  }
+
+  static discoverRegisteredToolNames(): string[] {
+    const names = new Set<string>(McpServer.getBuiltinToolNames());
+
+    if (!fs.existsSync(PLUGIN_DIR)) {
+      return Array.from(names).sort((a, b) => a.localeCompare(b));
+    }
+
+    const pluginFiles = fs
+      .readdirSync(PLUGIN_DIR)
+      .filter((file) => file.endsWith(".js"));
+
+    for (const file of pluginFiles) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const plugin = require(path.join(PLUGIN_DIR, file));
+        if (plugin?.name && typeof plugin.name === "string") {
+          names.add(plugin.name);
+        }
+        if (typeof plugin?.register === "function") {
+          plugin.register({
+            registerTool(name: string) {
+              names.add(name);
+            },
+          });
+        }
+      } catch {
+        // Ignore plugin parse errors during discovery.
+      }
+    }
+
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }
+
+  static createToolSnapshot(
+    states: Record<string, boolean>,
+    registeredToolNames: string[] = McpServer.discoverRegisteredToolNames(),
+  ): Array<{ name: string; enabled: boolean }> {
+    const names = new Set<string>([
+      ...registeredToolNames,
+      ...Object.keys(states),
+    ]);
+
+    return Array.from(names)
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => ({
+        name,
+        enabled: states[name] !== false,
+      }));
+  }
+
+  constructor(config: ConfigPort, port: number = 8080) {
     this.wss = new WebSocketServer({ port });
     this.orchestratorLLM = new OllamaClient(); // 指示者LLM
     this.workerLLM = new OllamaClient(); // 作業者LLM
+    this.config = config;
 
     // ダミーのツールを登録
     this.registerTool("calculator", async (expression: string) => {
@@ -239,12 +304,93 @@ export class McpServer {
     logger.info(`Tool registered: ${name}`);
   }
 
+  public async listTools(): Promise<Array<{ name: string; enabled: boolean }>> {
+    const states = await this.config.getMcpToolStates();
+    return McpServer.createToolSnapshot({
+      ...Object.fromEntries(
+        Array.from(this.tools.keys()).map((toolName) => [toolName, true]),
+      ),
+      ...states,
+    });
+  }
+
+  private async isToolEnabled(toolName: string): Promise<boolean> {
+    const states = await this.config.getMcpToolStates();
+    return states[toolName] !== false;
+  }
+
   private async callTool(toolName: string, ...args: any[]): Promise<any> {
     const tool = this.tools.get(toolName);
     if (!tool) {
       throw new Error(`Tool not found: ${toolName}`);
     }
-    return tool(...args);
+    if (!(await this.isToolEnabled(toolName))) {
+      await this.recordToolInvocation(toolName, false);
+      throw new Error(`Tool is disabled: ${toolName}`);
+    }
+
+    try {
+      const result = await tool(...args);
+      await this.recordToolInvocation(toolName, true);
+      return result;
+    } catch (error) {
+      await this.recordToolInvocation(toolName, false);
+      throw error;
+    }
+  }
+
+  private async recordToolInvocation(
+    toolName: string,
+    success: boolean,
+  ): Promise<void> {
+    try {
+      await this.ensureToolCallCountsLoaded();
+      const nextCount = (this.toolCallCounts.get(toolName) ?? 0) + 1;
+      this.toolCallCounts.set(toolName, nextCount);
+      await writeChatEventLog({
+        timestamp: new Date().toISOString(),
+        session_id: MCP_SERVER_SESSION_ID,
+        event_type: "mcp_tool_call",
+        mcp_tool_name: toolName,
+        mcp_server_name: MCP_SERVER_NAME,
+        mcp_success: success,
+        mcp_call_count: nextCount,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Failed to persist MCP tool invocation log: ${message}`);
+    }
+  }
+
+  private async ensureToolCallCountsLoaded(): Promise<void> {
+    if (this.toolCallCountsLoaded) {
+      return;
+    }
+    if (this.toolCallCountsLoadPromise) {
+      await this.toolCallCountsLoadPromise;
+      return;
+    }
+
+    this.toolCallCountsLoadPromise = (async () => {
+      const entries = await readLatestMcpToolEntries();
+      entries.forEach((entry, toolName) => {
+        if (typeof entry.mcp_call_count !== "number") {
+          return;
+        }
+        const current = this.toolCallCounts.get(toolName) ?? 0;
+        this.toolCallCounts.set(
+          toolName,
+          Math.max(current, entry.mcp_call_count),
+        );
+      });
+      this.toolCallCountsLoaded = true;
+    })();
+
+    try {
+      await this.toolCallCountsLoadPromise;
+    } finally {
+      this.toolCallCountsLoadPromise = null;
+    }
   }
 
   private loadPlugins() {
@@ -265,6 +411,8 @@ export class McpServer {
         const plugin = require(pluginPath);
         if (plugin.name && typeof plugin.handler === "function") {
           this.registerTool(plugin.name, plugin.handler);
+        } else if (typeof plugin.register === "function") {
+          plugin.register(this);
         } else {
           logger.warn(
             `Invalid plugin format: ${file}. Must export 'name' and 'handler' function.`,

--- a/src/operations/logging/chat-event-logger.ts
+++ b/src/operations/logging/chat-event-logger.ts
@@ -175,19 +175,24 @@ export async function readChatEventLogEntries(
     });
     const selected: ChatEventLogEntry[] = [];
 
-    for await (const line of reader) {
-      if (!line) {
-        continue;
-      }
-      try {
-        const entry = JSON.parse(line) as ChatEventLogEntry;
-        selected.push(entry);
-        if (limit > 0 && selected.length > limit) {
-          selected.shift();
+    try {
+      for await (const line of reader) {
+        if (!line) {
+          continue;
         }
-      } catch {
-        // Ignore malformed log lines.
+        try {
+          const entry = JSON.parse(line) as ChatEventLogEntry;
+          selected.push(entry);
+          if (limit > 0 && selected.length > limit) {
+            selected.shift();
+          }
+        } catch {
+          // Ignore malformed log lines.
+        }
       }
+    } finally {
+      reader.close();
+      stream.destroy();
     }
 
     return selected;
@@ -211,18 +216,23 @@ export async function readLatestMcpToolEntries(): Promise<
     });
     const entries = new Map<string, ChatEventLogEntry>();
 
-    for await (const line of reader) {
-      if (!line) {
-        continue;
-      }
-      try {
-        const entry = JSON.parse(line) as ChatEventLogEntry;
-        if (entry.event_type === "mcp_tool_call" && entry.mcp_tool_name) {
-          entries.set(entry.mcp_tool_name, entry);
+    try {
+      for await (const line of reader) {
+        if (!line) {
+          continue;
         }
-      } catch {
-        // Ignore malformed log lines.
+        try {
+          const entry = JSON.parse(line) as ChatEventLogEntry;
+          if (entry.event_type === "mcp_tool_call" && entry.mcp_tool_name) {
+            entries.set(entry.mcp_tool_name, entry);
+          }
+        } catch {
+          // Ignore malformed log lines.
+        }
       }
+    } finally {
+      reader.close();
+      stream.destroy();
     }
 
     return entries;

--- a/src/operations/logging/chat-event-logger.ts
+++ b/src/operations/logging/chat-event-logger.ts
@@ -1,6 +1,7 @@
-import { promises as fsp } from "fs";
+import { createReadStream, promises as fsp } from "fs";
 import * as os from "os";
 import * as path from "path";
+import * as readline from "readline";
 import { ModelResolutionSource } from "../../shared/types/chat";
 import { RoleName } from "../../domain/orchestration/entities/role";
 
@@ -22,7 +23,9 @@ export interface ChatEventLogEntry {
     | "context_summarize"
     | "turn_completed"
     | "turn_failed"
-    | "role_delegation";
+    | "role_delegation"
+    | "mcp_tool_call"
+    | "mcp_tool_state_change";
   model?: string;
   resolution_source?: ModelResolutionSource;
   user_input?: string;
@@ -39,6 +42,12 @@ export interface ChatEventLogEntry {
   loop_trigger?: "retry_limit" | "cycle_limit";
   loop_threshold?: number;
   loop_recent_history?: string[];
+  mcp_tool_name?: string;
+  mcp_server_name?: string;
+  mcp_success?: boolean;
+  mcp_call_count?: number;
+  mcp_enabled?: boolean;
+  mcp_previous_enabled?: boolean;
 }
 
 export type ChatEventLogger = (entry: ChatEventLogEntry) => Promise<void>;
@@ -154,3 +163,74 @@ export const writeChatEventLog: ChatEventLogger = async (entry) => {
   }
   await safeChmod(logFile, 0o600);
 };
+
+export async function readChatEventLogEntries(
+  limit: number = 200,
+): Promise<ChatEventLogEntry[]> {
+  try {
+    const stream = createReadStream(resolveLogFile(), { encoding: "utf-8" });
+    const reader = readline.createInterface({
+      input: stream,
+      crlfDelay: Infinity,
+    });
+    const selected: ChatEventLogEntry[] = [];
+
+    for await (const line of reader) {
+      if (!line) {
+        continue;
+      }
+      try {
+        const entry = JSON.parse(line) as ChatEventLogEntry;
+        selected.push(entry);
+        if (limit > 0 && selected.length > limit) {
+          selected.shift();
+        }
+      } catch {
+        // Ignore malformed log lines.
+      }
+    }
+
+    return selected;
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function readLatestMcpToolEntries(): Promise<
+  Map<string, ChatEventLogEntry>
+> {
+  try {
+    const stream = createReadStream(resolveLogFile(), { encoding: "utf-8" });
+    const reader = readline.createInterface({
+      input: stream,
+      crlfDelay: Infinity,
+    });
+    const entries = new Map<string, ChatEventLogEntry>();
+
+    for await (const line of reader) {
+      if (!line) {
+        continue;
+      }
+      try {
+        const entry = JSON.parse(line) as ChatEventLogEntry;
+        if (entry.event_type === "mcp_tool_call" && entry.mcp_tool_name) {
+          entries.set(entry.mcp_tool_name, entry);
+        }
+      } catch {
+        // Ignore malformed log lines.
+      }
+    }
+
+    return entries;
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT") {
+      return new Map();
+    }
+    throw error;
+  }
+}

--- a/src/ports/outbound/config.port.ts
+++ b/src/ports/outbound/config.port.ts
@@ -1,4 +1,8 @@
+export type McpToolStates = Record<string, boolean>;
+
 export interface ConfigPort {
   getDefaultModel(): Promise<string>;
   setDefaultModel(model: string): Promise<void>;
+  getMcpToolStates(): Promise<McpToolStates>;
+  setMcpToolEnabled(toolName: string, enabled: boolean): Promise<void>;
 }

--- a/src/tests/acceptance/features/F-003.model-selection.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-003.model-selection.acceptance.test.ts
@@ -1,6 +1,6 @@
-import { ResolveModelUseCase } from '../../../application/model-endpoint/resolve-model.usecase';
-import { ConfigPort } from '../../../ports/outbound/config.port';
-import { SessionStorePort } from '../../../ports/outbound/session-store.port';
+import { ResolveModelUseCase } from "../../../application/model-endpoint/resolve-model.usecase";
+import { ConfigPort } from "../../../ports/outbound/config.port";
+import { SessionStorePort } from "../../../ports/outbound/session-store.port";
 
 class FixedConfig implements ConfigPort {
   constructor(private readonly model: string) {}
@@ -10,6 +10,15 @@ class FixedConfig implements ConfigPort {
   }
 
   async setDefaultModel(_model: string): Promise<void> {}
+
+  async getMcpToolStates(): Promise<Record<string, boolean>> {
+    return {};
+  }
+
+  async setMcpToolEnabled(
+    _toolName: string,
+    _enabled: boolean,
+  ): Promise<void> {}
 }
 
 class InMemorySessionStore implements SessionStorePort {
@@ -24,36 +33,45 @@ class InMemorySessionStore implements SessionStorePort {
   }
 }
 
-describe('F-003 Model Selection acceptance', () => {
-  it('uses CLI model first', async () => {
+describe("F-003 Model Selection acceptance", () => {
+  it("uses CLI model first", async () => {
     const store = new InMemorySessionStore();
-    await store.setModel('s1', 'session-model');
-    const useCase = new ResolveModelUseCase(new FixedConfig('default-model'), store);
+    await store.setModel("s1", "session-model");
+    const useCase = new ResolveModelUseCase(
+      new FixedConfig("default-model"),
+      store,
+    );
 
     const result = await useCase.execute({
-      sessionId: 's1',
-      cliModel: 'cli-model',
+      sessionId: "s1",
+      cliModel: "cli-model",
     });
 
-    expect(result).toEqual({ model: 'cli-model', source: 'cli' });
+    expect(result).toEqual({ model: "cli-model", source: "cli" });
   });
 
-  it('uses session model when CLI model is absent', async () => {
+  it("uses session model when CLI model is absent", async () => {
     const store = new InMemorySessionStore();
-    await store.setModel('s1', 'session-model');
-    const useCase = new ResolveModelUseCase(new FixedConfig('default-model'), store);
+    await store.setModel("s1", "session-model");
+    const useCase = new ResolveModelUseCase(
+      new FixedConfig("default-model"),
+      store,
+    );
 
-    const result = await useCase.execute({ sessionId: 's1' });
+    const result = await useCase.execute({ sessionId: "s1" });
 
-    expect(result).toEqual({ model: 'session-model', source: 'session' });
+    expect(result).toEqual({ model: "session-model", source: "session" });
   });
 
-  it('uses default model when neither CLI nor session model is set', async () => {
+  it("uses default model when neither CLI nor session model is set", async () => {
     const store = new InMemorySessionStore();
-    const useCase = new ResolveModelUseCase(new FixedConfig('default-model'), store);
+    const useCase = new ResolveModelUseCase(
+      new FixedConfig("default-model"),
+      store,
+    );
 
-    const result = await useCase.execute({ sessionId: 's1' });
+    const result = await useCase.execute({ sessionId: "s1" });
 
-    expect(result).toEqual({ model: 'default-model', source: 'default' });
+    expect(result).toEqual({ model: "default-model", source: "default" });
   });
 });

--- a/src/tests/acceptance/features/F-004.session.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-004.session.acceptance.test.ts
@@ -15,6 +15,15 @@ class FixedConfig implements ConfigPort {
   }
 
   async setDefaultModel(_model: string): Promise<void> {}
+
+  async getMcpToolStates(): Promise<Record<string, boolean>> {
+    return {};
+  }
+
+  async setMcpToolEnabled(
+    _toolName: string,
+    _enabled: boolean,
+  ): Promise<void> {}
 }
 
 class SpyLlmClient implements LlmClientPort {

--- a/src/tests/acceptance/features/F-005.context.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-005.context.acceptance.test.ts
@@ -14,6 +14,15 @@ class FixedConfig implements ConfigPort {
   }
 
   async setDefaultModel(_model: string): Promise<void> {}
+
+  async getMcpToolStates(): Promise<Record<string, boolean>> {
+    return {};
+  }
+
+  async setMcpToolEnabled(
+    _toolName: string,
+    _enabled: boolean,
+  ): Promise<void> {}
 }
 
 class NoopLlmClient implements LlmClientPort {

--- a/src/tests/acceptance/features/F-201.mcp-tool-visibility.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-201.mcp-tool-visibility.acceptance.test.ts
@@ -1,0 +1,41 @@
+import { promises as fsp } from "fs";
+import * as os from "os";
+import * as path from "path";
+import { McpServer } from "../../../mcp/McpServer";
+
+describe("F-201 MCP tool visibility acceptance", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "f201-mcp-"));
+    process.env.CHAT_EVENT_LOG_FILE = path.join(tempDir, "chat-events.jsonl");
+  });
+
+  afterEach(async () => {
+    delete process.env.CHAT_EVENT_LOG_FILE;
+    await fsp.rm(tempDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it("records which MCP tool was used and whether it succeeded", async () => {
+    const server = Object.create(McpServer.prototype) as any;
+    server.tools = new Map([["calculator", jest.fn().mockResolvedValue("ok")]]);
+    server.toolCallCounts = new Map();
+    server.config = {
+      getMcpToolStates: jest.fn().mockResolvedValue({
+        calculator: true,
+      }),
+    };
+
+    await server.callTool("calculator", "1+1");
+
+    const content = await fsp.readFile(
+      process.env.CHAT_EVENT_LOG_FILE!,
+      "utf-8",
+    );
+    expect(content).toContain('"event_type":"mcp_tool_call"');
+    expect(content).toContain('"mcp_tool_name":"calculator"');
+    expect(content).toContain('"mcp_server_name":"local-control-node"');
+    expect(content).toContain('"mcp_success":true');
+  });
+});

--- a/src/tests/acceptance/features/F-202.mcp-management.acceptance.test.ts
+++ b/src/tests/acceptance/features/F-202.mcp-management.acceptance.test.ts
@@ -1,0 +1,91 @@
+import { createProgram } from "../../../main";
+import { RunChatUseCase } from "../../../application/chat/run-chat.usecase";
+import * as chatEventLogger from "../../../operations/logging/chat-event-logger";
+import { ConfigPort } from "../../../ports/outbound/config.port";
+
+function createMockUseCase() {
+  return {
+    startSession: jest.fn(),
+    runTurn: jest.fn(),
+    loadContext: jest.fn(),
+    recordTurn: jest.fn(),
+    setContextPolicy: jest.fn(),
+    saveSession: jest.fn(),
+    loadSession: jest.fn(),
+    getSession: jest.fn(),
+    endSession: jest.fn(),
+    clearContext: jest.fn(),
+    summarizeContext: jest.fn(),
+  } as unknown as RunChatUseCase;
+}
+
+function createMockConfig(): ConfigPort {
+  return {
+    getDefaultModel: jest.fn().mockResolvedValue("test-model"),
+    setDefaultModel: jest.fn().mockResolvedValue(undefined),
+    getMcpToolStates: jest.fn().mockResolvedValue({
+      calculator: true,
+      grep: false,
+    }),
+    setMcpToolEnabled: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("F-202 MCP management acceptance", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows readable results for list/enable/disable/status", async () => {
+    const config = createMockConfig();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(chatEventLogger, "readLatestMcpToolEntries").mockResolvedValue(
+      new Map([
+        [
+          "calculator",
+          {
+            timestamp: "2026-02-28T22:40:00.000Z",
+            session_id: "mcp-server",
+            event_type: "mcp_tool_call",
+            mcp_tool_name: "calculator",
+            mcp_success: true,
+            mcp_call_count: 2,
+          },
+        ],
+      ]),
+    );
+
+    let program = createProgram({
+      useCase: createMockUseCase(),
+      config,
+    });
+    await program.parseAsync(["mcp", "list"], { from: "user" });
+    expect(logSpy).toHaveBeenCalledWith("MCPツール一覧:");
+
+    program = createProgram({
+      useCase: createMockUseCase(),
+      config,
+    });
+    await program.parseAsync(["mcp", "status", "calculator"], { from: "user" });
+    expect(logSpy).toHaveBeenCalledWith("tool=calculator");
+    expect(logSpy).toHaveBeenCalledWith("status=enabled");
+    expect(logSpy).toHaveBeenCalledWith("call_count=2");
+
+    program = createProgram({
+      useCase: createMockUseCase(),
+      config,
+    });
+    await program.parseAsync(["mcp", "enable", "grep"], { from: "user" });
+    expect(config.setMcpToolEnabled).toHaveBeenCalledWith("grep", true);
+
+    program = createProgram({
+      useCase: createMockUseCase(),
+      config,
+    });
+    await program.parseAsync(["mcp", "disable", "calculator"], {
+      from: "user",
+    });
+    expect(config.setMcpToolEnabled).toHaveBeenCalledWith("calculator", false);
+  });
+});

--- a/src/tests/unit/application/main.program.test.ts
+++ b/src/tests/unit/application/main.program.test.ts
@@ -1,6 +1,7 @@
 import { createProgram } from "../../../main";
 import { RunChatUseCase } from "../../../application/chat/run-chat.usecase";
 import * as chatEventLogger from "../../../operations/logging/chat-event-logger";
+import { ConfigPort } from "../../../ports/outbound/config.port";
 
 function createMockUseCase() {
   return {
@@ -12,12 +13,10 @@ function createMockUseCase() {
     runTurn: jest.fn(async function* () {
       yield "ok";
     }),
-    loadContext: jest
-      .fn()
-      .mockResolvedValue({
-        messages: [],
-        policy: { maxTurns: 10, summaryEnabled: false },
-      }),
+    loadContext: jest.fn().mockResolvedValue({
+      messages: [],
+      policy: { maxTurns: 10, summaryEnabled: false },
+    }),
     recordTurn: jest.fn().mockResolvedValue(undefined),
     setContextPolicy: jest.fn().mockResolvedValue({
       policy: { maxTurns: 5, summaryEnabled: true },
@@ -51,6 +50,18 @@ function createMockUseCase() {
       .fn()
       .mockResolvedValue({ messages: [], summary: "s" }),
   } as unknown as RunChatUseCase;
+}
+
+function createMockConfig(): ConfigPort {
+  return {
+    getDefaultModel: jest.fn().mockResolvedValue("test-model"),
+    setDefaultModel: jest.fn().mockResolvedValue(undefined),
+    getMcpToolStates: jest.fn().mockResolvedValue({
+      calculator: true,
+      grep: false,
+    }),
+    setMcpToolEnabled: jest.fn().mockResolvedValue(undefined),
+  };
 }
 
 describe("createProgram", () => {
@@ -159,5 +170,167 @@ describe("createProgram", () => {
         event_type: "session_save",
       }),
     );
+  });
+
+  it("registers mcp subcommands without duplicate command error", () => {
+    const program = createProgram();
+    const mcp = program.commands.find((cmd) => cmd.name() === "mcp");
+
+    expect(mcp).toBeDefined();
+    expect(mcp?.commands.map((cmd) => cmd.name())).toEqual(
+      expect.arrayContaining(["list", "enable", "disable", "status"]),
+    );
+  });
+
+  it("lists MCP tools and their status", async () => {
+    const useCase = createMockUseCase();
+    const config = createMockConfig();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest
+      .spyOn(chatEventLogger, "readLatestMcpToolEntries")
+      .mockResolvedValue(new Map());
+
+    const program = createProgram({ useCase, config });
+    await program.parseAsync(["mcp", "list"], {
+      from: "user",
+    });
+
+    expect(config.getMcpToolStates).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith("MCPツール一覧:");
+    expect(logSpy).toHaveBeenCalledWith("  - calculator: enabled");
+    expect(logSpy).toHaveBeenCalledWith("  - grep: disabled");
+  });
+
+  it("includes built-in MCP tools even when config has no explicit state", async () => {
+    const useCase = createMockUseCase();
+    const config: ConfigPort = {
+      getDefaultModel: jest.fn().mockResolvedValue("test-model"),
+      setDefaultModel: jest.fn().mockResolvedValue(undefined),
+      getMcpToolStates: jest.fn().mockResolvedValue({}),
+      setMcpToolEnabled: jest.fn().mockResolvedValue(undefined),
+    };
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest
+      .spyOn(chatEventLogger, "readLatestMcpToolEntries")
+      .mockResolvedValue(new Map());
+
+    const program = createProgram({ useCase, config });
+    await program.parseAsync(["mcp", "list"], { from: "user" });
+
+    expect(logSpy).toHaveBeenCalledWith("  - calculator: enabled");
+  });
+
+  it("shows recent MCP usage metadata in status output", async () => {
+    const useCase = createMockUseCase();
+    const config = createMockConfig();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(chatEventLogger, "readLatestMcpToolEntries").mockResolvedValue(
+      new Map([
+        [
+          "calculator",
+          {
+            timestamp: "2026-02-28T22:30:00.000Z",
+            session_id: "mcp-server",
+            event_type: "mcp_tool_call",
+            mcp_tool_name: "calculator",
+            mcp_success: true,
+            mcp_call_count: 3,
+          },
+        ],
+      ]),
+    );
+
+    const program = createProgram({ useCase, config });
+    await program.parseAsync(["mcp", "status", "calculator"], {
+      from: "user",
+    });
+
+    expect(logSpy).toHaveBeenCalledWith("tool=calculator");
+    expect(logSpy).toHaveBeenCalledWith("status=enabled");
+    expect(logSpy).toHaveBeenCalledWith("call_count=3");
+    expect(logSpy).toHaveBeenCalledWith("last_success=yes");
+    expect(logSpy).toHaveBeenCalledWith(
+      "last_called_at=2026-02-28T22:30:00.000Z",
+    );
+  });
+
+  it("rejects unknown MCP tools for status changes", async () => {
+    const useCase = createMockUseCase();
+    const config: ConfigPort = {
+      getDefaultModel: jest.fn().mockResolvedValue("test-model"),
+      setDefaultModel: jest.fn().mockResolvedValue(undefined),
+      getMcpToolStates: jest.fn().mockResolvedValue({}),
+      setMcpToolEnabled: jest.fn().mockResolvedValue(undefined),
+    };
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest
+      .spyOn(chatEventLogger, "readLatestMcpToolEntries")
+      .mockResolvedValue(new Map());
+
+    const program = createProgram({ useCase, config });
+    await program.parseAsync(["mcp", "enable", "unknown-tool"], {
+      from: "user",
+    });
+
+    expect(config.setMcpToolEnabled).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "MCPツールの有効化に失敗しました: Tool not found: unknown-tool",
+    );
+  });
+
+  it("still enables an MCP tool when log history cannot be read", async () => {
+    const useCase = createMockUseCase();
+    const config = createMockConfig();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest
+      .spyOn(chatEventLogger, "readLatestMcpToolEntries")
+      .mockRejectedValue(new Error("permission denied"));
+
+    const program = createProgram({ useCase, config });
+    await program.parseAsync(["mcp", "enable", "grep"], {
+      from: "user",
+    });
+
+    expect(config.setMcpToolEnabled).toHaveBeenCalledWith("grep", true);
+  });
+
+  it("updates MCP tool status with enable and disable commands", async () => {
+    const useCase = createMockUseCase();
+    const config = createMockConfig();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    const writeLogSpy = jest
+      .spyOn(chatEventLogger, "writeChatEventLog")
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(chatEventLogger, "readLatestMcpToolEntries")
+      .mockResolvedValue(new Map());
+
+    let program = createProgram({ useCase, config });
+    await program.parseAsync(["mcp", "enable", "grep"], {
+      from: "user",
+    });
+
+    expect(config.setMcpToolEnabled).toHaveBeenCalledWith("grep", true);
+    expect(writeLogSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: "mcp_tool_state_change",
+        mcp_tool_name: "grep",
+        mcp_previous_enabled: false,
+        mcp_enabled: true,
+      }),
+    );
+
+    program = createProgram({ useCase, config });
+    await program.parseAsync(["mcp", "disable", "calculator"], {
+      from: "user",
+    });
+
+    expect(config.setMcpToolEnabled).toHaveBeenCalledWith("calculator", false);
   });
 });

--- a/src/tests/unit/application/run-chat.usecase.test.ts
+++ b/src/tests/unit/application/run-chat.usecase.test.ts
@@ -52,6 +52,15 @@ class FakeConfig implements ConfigPort {
   }
 
   async setDefaultModel(_model: string): Promise<void> {}
+
+  async getMcpToolStates(): Promise<Record<string, boolean>> {
+    return {};
+  }
+
+  async setMcpToolEnabled(
+    _toolName: string,
+    _enabled: boolean,
+  ): Promise<void> {}
 }
 
 class FakeLlmClient implements LlmClientPort {

--- a/src/tests/unit/mcp/mcp.server.test.ts
+++ b/src/tests/unit/mcp/mcp.server.test.ts
@@ -175,12 +175,4 @@ describe("McpServer arithmetic evaluator", () => {
       }),
     );
   });
-
-  it("rejects non-local browser origins", () => {
-    const serverClass = McpServer as any;
-
-    expect(serverClass.isTrustedOrigin(undefined)).toBe(true);
-    expect(serverClass.isTrustedOrigin("http://localhost:3000")).toBe(true);
-    expect(serverClass.isTrustedOrigin("https://example.com")).toBe(false);
-  });
 });

--- a/src/tests/unit/mcp/mcp.server.test.ts
+++ b/src/tests/unit/mcp/mcp.server.test.ts
@@ -4,6 +4,7 @@ import { promises as fsp } from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as chatEventLogger from "../../../operations/logging/chat-event-logger";
+import { logger } from "../../../utils/logger";
 
 describe("McpServer arithmetic evaluator", () => {
   let tempDir: string;
@@ -14,6 +15,7 @@ describe("McpServer arithmetic evaluator", () => {
   });
 
   afterEach(async () => {
+    jest.restoreAllMocks();
     delete process.env.CHAT_EVENT_LOG_FILE;
     await fsp.rm(tempDir, { recursive: true, force: true });
   });
@@ -142,5 +144,43 @@ describe("McpServer arithmetic evaluator", () => {
         mcp_call_count: 6,
       }),
     );
+  });
+
+  it("treats log history load failures as an empty baseline", async () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(logger, "warn").mockResolvedValue(undefined);
+    jest
+      .spyOn(chatEventLogger, "readLatestMcpToolEntries")
+      .mockRejectedValue(new Error("permission denied"));
+    const writeLogSpy = jest
+      .spyOn(chatEventLogger, "writeChatEventLog")
+      .mockResolvedValue(undefined);
+    const server = Object.create(McpServer.prototype) as any;
+    server.tools = new Map([["calculator", jest.fn().mockResolvedValue("ok")]]);
+    server.toolCallCounts = new Map();
+    server.toolCallCountsLoaded = false;
+    server.toolCallCountsLoadPromise = null;
+    server.config = {
+      getMcpToolStates: jest.fn().mockResolvedValue({
+        calculator: true,
+      }),
+    };
+
+    await expect(server.callTool("calculator", "1+1")).resolves.toBe("ok");
+
+    expect(writeLogSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        mcp_tool_name: "calculator",
+        mcp_call_count: 1,
+      }),
+    );
+  });
+
+  it("rejects non-local browser origins", () => {
+    const serverClass = McpServer as any;
+
+    expect(serverClass.isTrustedOrigin(undefined)).toBe(true);
+    expect(serverClass.isTrustedOrigin("http://localhost:3000")).toBe(true);
+    expect(serverClass.isTrustedOrigin("https://example.com")).toBe(false);
   });
 });

--- a/src/tests/unit/mcp/mcp.server.test.ts
+++ b/src/tests/unit/mcp/mcp.server.test.ts
@@ -1,6 +1,23 @@
 import { evaluateArithmeticExpression } from "../../../mcp/McpServer";
+import { McpServer } from "../../../mcp/McpServer";
+import { promises as fsp } from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as chatEventLogger from "../../../operations/logging/chat-event-logger";
 
 describe("McpServer arithmetic evaluator", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "mcp-unit-"));
+    process.env.CHAT_EVENT_LOG_FILE = path.join(tempDir, "chat-events.jsonl");
+  });
+
+  afterEach(async () => {
+    delete process.env.CHAT_EVENT_LOG_FILE;
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  });
+
   it("evaluates basic expressions with precedence", () => {
     expect(evaluateArithmeticExpression("1 + 2 * 3")).toBe(7);
     expect(evaluateArithmeticExpression("(1 + 2) * 3")).toBe(9);
@@ -29,6 +46,101 @@ describe("McpServer arithmetic evaluator", () => {
     );
     expect(() => evaluateArithmeticExpression("(1 + 2")).toThrow(
       "Mismatched parentheses",
+    );
+  });
+
+  it("lists tool status from config and built-in registrations", async () => {
+    const server = Object.create(McpServer.prototype) as any;
+    server.tools = new Map([["calculator", jest.fn()]]);
+    server.config = {
+      getMcpToolStates: jest.fn().mockResolvedValue({
+        calculator: true,
+        grep: false,
+      }),
+    };
+
+    await expect(server.listTools()).resolves.toEqual([
+      { name: "calculator", enabled: true },
+      { name: "grep", enabled: false },
+    ]);
+  });
+
+  it("rejects disabled tools before execution", async () => {
+    const server = Object.create(McpServer.prototype) as any;
+    const tool = jest.fn().mockResolvedValue("ok");
+    server.tools = new Map([["calculator", tool]]);
+    server.toolCallCounts = new Map();
+    server.config = {
+      getMcpToolStates: jest.fn().mockResolvedValue({
+        calculator: false,
+      }),
+    };
+
+    await expect(server.callTool("calculator", "1+1")).rejects.toThrow(
+      "Tool is disabled: calculator",
+    );
+    expect(tool).not.toHaveBeenCalled();
+  });
+
+  it("keeps tool execution successful even when logging fails", async () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    const writeLogSpy = jest
+      .spyOn(chatEventLogger, "writeChatEventLog")
+      .mockRejectedValue(new Error("disk full"));
+    const server = Object.create(McpServer.prototype) as any;
+    const tool = jest.fn().mockResolvedValue("ok");
+    server.tools = new Map([["calculator", tool]]);
+    server.toolCallCounts = new Map();
+    server.config = {
+      getMcpToolStates: jest.fn().mockResolvedValue({
+        calculator: true,
+      }),
+    };
+
+    await expect(server.callTool("calculator", "1+1")).resolves.toBe("ok");
+    expect(writeLogSpy).toHaveBeenCalled();
+  });
+
+  it("loads persisted tool call counts only once before incrementing in memory", async () => {
+    const readLogSpy = jest
+      .spyOn(chatEventLogger, "readLatestMcpToolEntries")
+      .mockResolvedValue(
+        new Map([
+          [
+            "calculator",
+            {
+              timestamp: "2026-03-01T00:00:00.000Z",
+              session_id: "mcp-server",
+              event_type: "mcp_tool_call",
+              mcp_tool_name: "calculator",
+              mcp_success: true,
+              mcp_call_count: 4,
+            },
+          ],
+        ]),
+      );
+    const writeLogSpy = jest
+      .spyOn(chatEventLogger, "writeChatEventLog")
+      .mockResolvedValue(undefined);
+    const server = Object.create(McpServer.prototype) as any;
+    server.tools = new Map([["calculator", jest.fn().mockResolvedValue("ok")]]);
+    server.toolCallCounts = new Map();
+    server.toolCallCountsLoaded = false;
+    server.config = {
+      getMcpToolStates: jest.fn().mockResolvedValue({
+        calculator: true,
+      }),
+    };
+
+    await expect(server.callTool("calculator", "1+1")).resolves.toBe("ok");
+    await expect(server.callTool("calculator", "1+1")).resolves.toBe("ok");
+
+    expect(readLogSpy).toHaveBeenCalledTimes(1);
+    expect(writeLogSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        mcp_tool_name: "calculator",
+        mcp_call_count: 6,
+      }),
     );
   });
 });


### PR DESCRIPTION
## 概要 (Summary)
Issue #41 向けに、MCP 管理コマンドとツール呼び出し可視化を追加しました。`mcp list/enable/disable/status` を CLI から操作できるようにし、MCP ツール状態の永続化、利用メタ情報の表示、ログ読込の堅牢化まで含めて整備しています。

## 関連Issue (Related Issues)
Closes #41

## 変更の種類 (Type of Change)
- [x] 新機能 (New feature)
- [x] バグ修正 (Bug fix)
- [ ] リファクタリング (Refactoring)
- [ ] ドキュメント更新 (Documentation)

## 詳細な変更点 (Detailed Changes)
- `src/main.ts`: `mcp list/enable/disable/status` を追加し、ツール状態表示と利用メタ情報表示、管理操作ログを実装。
- `src/mcp/McpServer.ts`: ツール一覧取得、無効ツール拒否、プラグイン登録検出、MCP 呼び出しカウントの起動時復元とメモリ管理を追加。
- `src/operations/logging/chat-event-logger.ts`: MCP イベント項目を拡張し、ストリーム読込ベースのログ参照 API を追加。
- `src/adapters/config/file-config.adapter.ts`: `config.json` に MCP ツールの enabled/disabled 状態を保存できるよう拡張。
- `src/ports/outbound/config.port.ts`: MCP ツール状態の取得・更新インターフェースを追加。
- `src/tests/unit/application/main.program.test.ts`: MCP コマンドの登録、表示、ログ失敗時フォールバックを検証。
- `src/tests/unit/mcp/mcp.server.test.ts`: ツール一覧、無効化、ログ失敗耐性、呼出回数復元を検証。
- `src/tests/acceptance/features/F-201.mcp-tool-visibility.acceptance.test.ts`: 使用ツールと成否の可視化を検証。
- `src/tests/acceptance/features/F-202.mcp-management.acceptance.test.ts`: `mcp list/enable/disable/status` の受け入れ動作を検証。
- `src/tests/acceptance/features/F-003.model-selection.acceptance.test.ts`, `src/tests/acceptance/features/F-004.session.acceptance.test.ts`, `src/tests/acceptance/features/F-005.context.acceptance.test.ts`, `src/tests/unit/application/run-chat.usecase.test.ts`: `ConfigPort` 拡張に追従するテストダブルを追加。

## 動作確認手順 (Verification Steps)
1. `npm test` がパスすること
2. `npm test -- src/tests/unit/application/main.program.test.ts src/tests/unit/mcp/mcp.server.test.ts src/tests/unit/operations/chat-event-logger.test.ts src/tests/acceptance/features/F-201.mcp-tool-visibility.acceptance.test.ts src/tests/acceptance/features/F-202.mcp-management.acceptance.test.ts`
3. `multi-llm-agent-cli mcp list` / `multi-llm-agent-cli mcp status <tool>` で状態と利用メタ情報が確認できること

## 自己チェック (Self Check)
- [x] 既存のテストを壊していないか
- [x] 機密情報（API Key等）が含まれていないか
